### PR TITLE
Attempt to parse project from .tfplan before asking for --project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ export POLICY_PATH=/path/to/your/forseti-config-policies/repo
 terraform plan --out=terraform.tfplan
 
 # Validate the google resources the plan would create.
-terraform-validator validate --project=${TF_VAR_project_id} --policy-path=${POLICY_PATH} ./terraform.tfplan
+terraform-validator validate --policy-path=${POLICY_PATH} ./terraform.tfplan
 
 # Apply the validated plan.
 terraform apply ./terraform.tfplan

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -47,6 +47,9 @@ Example:
 	RunE: func(c *cobra.Command, args []string) error {
 		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project)
 		if err != nil {
+			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
+				return errors.New("unable to parse provider project, please use --project flag")
+			}
 			return errors.Wrap(err, "converting tfplan to CAI assets")
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,11 +27,9 @@ func init() {
 
 	validateCmd.Flags().StringVar(&flags.validate.policyPath, "policy-path", "", "Path to directory containing validation policies")
 	validateCmd.MarkFlagRequired("policy-path")
-	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project")
-	validateCmd.MarkFlagRequired("project")
+	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project override")
 
-	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project")
-	convertCmd.MarkFlagRequired("project")
+	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project override")
 
 	validateCmd.Flags().BoolVar(&flags.validate.outputJSON, "output-json", false, "Print violations as JSON")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,9 +27,9 @@ func init() {
 
 	validateCmd.Flags().StringVar(&flags.validate.policyPath, "policy-path", "", "Path to directory containing validation policies")
 	validateCmd.MarkFlagRequired("policy-path")
-	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project override")
+	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when validating resources)")
 
-	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project override")
+	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when converting resources)")
 
 	validateCmd.Flags().BoolVar(&flags.validate.outputJSON, "output-json", false, "Print violations as JSON")
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -47,6 +47,9 @@ Example:
 	RunE: func(c *cobra.Command, args []string) error {
 		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project)
 		if err != nil {
+			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
+				return errors.New("unable to parse provider project, please use --project flag")
+			}
 			return errors.Wrap(err, "converting tfplan to CAI assets")
 		}
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -20,14 +20,15 @@ locals {
 
 provider "google" {
   version = "~> 1.20"
-  project = "${local.project}"
 }
 
 resource "google_compute_disk" "my-disk" {
-  name  = "my-disk"
-  type  = "pd-ssd"
-  zone  = "us-central1-a"
-  image = "debian-8-jessie-v20170523"
+  name    = "my-disk"
+  project = "${local.project}"
+  type    = "pd-ssd"
+  zone    = "us-central1-a"
+  image   = "debian-8-jessie-v20170523"
+
   labels = {
     foo = "bar"
   }
@@ -39,14 +40,18 @@ resource "random_id" "bucket" {
 
 resource "google_storage_bucket" "my-bucket" {
   name     = "my-bucket-${random_id.bucket.hex}"
+  project  = "${local.project}"
   location = "US"
+
   labels = {
     foo = "bar"
   }
+
   website = {
     main_page_suffix = "index.html"
     not_found_page   = "404.html"
   }
+
   cors = {
     origin = ["*"]
     method = ["POST"]
@@ -81,3 +86,4 @@ resource "google_project_iam_binding" "editors" {
   ]
 }
 */
+

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -89,5 +89,8 @@ func parseProviderProject(plan *terraform.Plan) (string, error) {
 		}
 	}
 
+	// If we have reached this point, there was no provider-level project that
+	// was specified in this plan. This means the plan should be viable based
+	// on resource-level project fields being set.
 	return "", nil
 }


### PR DESCRIPTION
The terraform plan contains an un-interpolated provider configuration. In this PR, we attempt to pull a hardcoded `project` field for the `google` provider rather than requiring it to be passed in via the flag `--project`. This PR does not attempt to run interpolations.