### PR TITLE
Implement .Id() in TerraformResourceData

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -33,6 +33,7 @@ var ErrDuplicateAsset = errors.New("duplicate asset")
 // TerraformResource represents the required methods needed to convert a terraform
 // resource into an Asset type.
 type TerraformResource interface {
+	Id() string
 	Kind() string
 	Get(string) interface{}
 	GetOk(string) (interface{}, bool)
@@ -47,7 +48,6 @@ type nonImplementedResourceData struct{}
 func (nonImplementedResourceData) HasChange(string) bool         { return false }
 func (nonImplementedResourceData) Set(string, interface{}) error { return nil }
 func (nonImplementedResourceData) SetId(string)                  {}
-func (nonImplementedResourceData) Id() string                    { return "" }
 
 // Asset contains the resource data and metadata in the same format as
 // Google CAI (Cloud Asset Inventory).

--- a/tfplan/fields.go
+++ b/tfplan/fields.go
@@ -55,6 +55,7 @@ func newFieldGetter(sch map[string]*schema.Schema, state *terraform.InstanceStat
 	return &fieldGetter{
 		rdr:    rdr,
 		schema: sch,
+		state:  state,
 	}
 }
 
@@ -63,6 +64,15 @@ func newFieldGetter(sch map[string]*schema.Schema, state *terraform.InstanceStat
 type fieldGetter struct {
 	rdr    schema.FieldReader
 	schema map[string]*schema.Schema
+	state  *terraform.InstanceState
+}
+
+// Id returns the ID of the resource from state.
+func (g *fieldGetter) Id() string {
+	if g.state != nil {
+		return g.state.ID
+	}
+	return ""
 }
 
 // Get reads a single field by key.

--- a/tfplan/plan_test.go
+++ b/tfplan/plan_test.go
@@ -31,6 +31,7 @@ func TestComposeResources(t *testing.T) {
 					Resources: map[string]*terraform.ResourceState{
 						"google_test_resource.test": &terraform.ResourceState{
 							Primary: &terraform.InstanceState{
+								ID: "my-id",
 								Attributes: map[string]string{
 									"my_number": "42",
 								},
@@ -71,4 +72,5 @@ func TestComposeResources(t *testing.T) {
 	resources := ComposeResources(plan, schemas)
 	require.Len(t, resources, 1)
 	require.Equal(t, 42, resources[0].Get("my_number"))
+	require.Equal(t, "my-id", resources[0].Id())
 }


### PR DESCRIPTION
`.Id()` can be used to check whether a resource has already been created.

**Use Case**
This is useful for converting `google_project` into multiple CAI resources (Project & ProjectBillingInfo)... If the project already exists, its billing info can be looked up. Otherwise, the converter will need to perform a best-attempt building of billing account by referencing optional fields such as `google_project.billing_account`.