### PR TITLE
add --folder flag to override ancestry discovery

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -36,7 +36,8 @@ Note:
   resources.
 
 Example:
-  terraform-validator convert ./example/terraform.tfplan --project my-project
+  terraform-validator convert ./example/terraform.tfplan --project my-project \
+    --ancestry organization/my-org/folder/my-folder
 `,
 	PreRunE: func(c *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -45,7 +46,7 @@ Example:
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project, flags.convert.ancestry)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,8 +28,10 @@ func init() {
 	validateCmd.Flags().StringVar(&flags.validate.policyPath, "policy-path", "", "Path to directory containing validation policies")
 	validateCmd.MarkFlagRequired("policy-path")
 	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when validating resources)")
+	validateCmd.Flags().StringVar(&flags.validate.ancestry, "ancestry", "", "Override the ancestry location of the project when validating resources")
 
 	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when converting resources)")
+	convertCmd.Flags().StringVar(&flags.convert.ancestry, "ancestry", "", "Override the ancestry location of the project when validating resources")
 
 	validateCmd.Flags().BoolVar(&flags.validate.outputJSON, "output-json", false, "Print violations as JSON")
 
@@ -47,10 +49,12 @@ var flags struct {
 
 	// flags that correspond to subcommands:
 	convert struct {
-		project string
+		project  string
+		ancestry string
 	}
 	validate struct {
 		project    string
+		ancestry   string
 		policyPath string
 		outputJSON bool
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -36,6 +36,7 @@ is set.
 Example:
   terraform-validator validate ./example/terraform.tfplan \
     --project my-project \
+    --ancestry organization/my-org/folder/my-folder \
     --policy-path ./path/to/my/gcv/policies
 `,
 	PreRunE: func(c *cobra.Command, args []string) error {
@@ -45,7 +46,7 @@ Example:
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project, flags.validate.ancestry)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -26,8 +26,10 @@ import (
 )
 
 // ReadPlannedAssets extracts CAI assets from a terraform plan file.
+// If ancestry path is provided, it assumes the project is in that path rather
+// than fetching the ancestry information using Google API.
 // It ignores non-supported resources.
-func ReadPlannedAssets(path, project string) ([]google.Asset, error) {
+func ReadPlannedAssets(path, project, ancestry string) ([]google.Asset, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening plan file")
@@ -47,7 +49,7 @@ func ReadPlannedAssets(path, project string) ([]google.Asset, error) {
 		}
 	}
 
-	converter, err := google.NewConverter(project, "")
+	converter, err := google.NewConverter(project, ancestry, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "building google converter")
 	}


### PR DESCRIPTION
The idea is to pre populate ancestry cache if `--folder` is provided from the command line. This should fix issue #21. 