### PR TITLE
Upgrade config validator library dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ credentials.json
 *.tfplan
 *.tfstate*
 
+# Visual Studio Code
+.vscode/

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
 	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20190403215538-710bfbc3d74a
-	github.com/forseti-security/config-validator v0.0.0-20190329215106-675a967a6af4
+	github.com/forseti-security/config-validator v0.0.0-20190518025122-10863ea54f95
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.1
 	github.com/hashicorp/go-getter v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/forseti-security/config-validator v0.0.0-20190329211748-4da95fb409f2 
 github.com/forseti-security/config-validator v0.0.0-20190329211748-4da95fb409f2/go.mod h1:FlLwurK5wdRaTgZmPOgHqFg2yActuCQaoanXIBqXV9g=
 github.com/forseti-security/config-validator v0.0.0-20190329215106-675a967a6af4 h1:Oze1MmP9DzxVynCvWqdiG+7/sLgczFC1a1xhNJ12RkQ=
 github.com/forseti-security/config-validator v0.0.0-20190329215106-675a967a6af4/go.mod h1:FlLwurK5wdRaTgZmPOgHqFg2yActuCQaoanXIBqXV9g=
+github.com/forseti-security/config-validator v0.0.0-20190518025122-10863ea54f95 h1:U+/f0a5vq2x0ib7dw42RPlZUwpvM++EkSHR5z7mwwdc=
+github.com/forseti-security/config-validator v0.0.0-20190518025122-10863ea54f95/go.mod h1:FlLwurK5wdRaTgZmPOgHqFg2yActuCQaoanXIBqXV9g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 h1:R+19WKQClnfMXS60cP5BmMe1wjZ4u0evY2p2Ar0ZTXo=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=


### PR DESCRIPTION
To pick up the latest version to handle format change (https://github.com/forseti-security/config-validator/issues/30).

Also add .vscode/ dir to .gitignore file.