### PR TITLE
Update user agent string since "terraform" is already taken

### DIFF
--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -55,9 +55,9 @@ func ReadPlannedAssets(path, project, ancestry string) ([]google.Asset, error) {
 	}
 
 	// Add User Agent string to indicate Terraform Validator usage.
-	// Do *NOT* change the "terraform-validator/" prefix, or else it will
+	// Do *NOT* change the "config-validator-tf/" prefix, or else it will
 	// break usage tracking.
-	ua := option.WithUserAgent(fmt.Sprintf("terraform-validator/%s", BuildVersion()))
+	ua := option.WithUserAgent(fmt.Sprintf("config-validator-tf/%s", BuildVersion()))
 	resourceManager, err := cloudresourcemanager.NewService(context.Background(), ua)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource manager client")


### PR DESCRIPTION
There is an existing entry of "terraform" in API attribution configuration. To avoid confusion, we'll switch to a unique string ("config-validator-tf") for terraform validator.