### PR TITLE
add offline flag

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -43,10 +43,14 @@ Example:
 		if len(args) != 1 {
 			return errors.New("missing required argument <tfplan>")
 		}
+		if flags.convert.offline && flags.convert.ancestry == "" {
+			return errors.New("please set ancestry via --ancestry in offline mode")
+		}
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project, flags.convert.ancestry)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project,
+			flags.convert.ancestry, flags.convert.offline)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,9 +29,11 @@ func init() {
 	validateCmd.MarkFlagRequired("policy-path")
 	validateCmd.Flags().StringVar(&flags.validate.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when validating resources)")
 	validateCmd.Flags().StringVar(&flags.validate.ancestry, "ancestry", "", "Override the ancestry location of the project when validating resources")
+	validateCmd.Flags().BoolVar(&flags.validate.offline, "offline", false, "Do not connect to GCP API")
 
 	convertCmd.Flags().StringVar(&flags.convert.project, "project", "", "Provider project override (override the default project configuration assigned to the google terraform provider when converting resources)")
 	convertCmd.Flags().StringVar(&flags.convert.ancestry, "ancestry", "", "Override the ancestry location of the project when validating resources")
+	convertCmd.Flags().BoolVar(&flags.convert.offline, "offline", false, "Do not connect to GCP API")
 
 	validateCmd.Flags().BoolVar(&flags.validate.outputJSON, "output-json", false, "Print violations as JSON")
 
@@ -52,10 +54,12 @@ var flags struct {
 	convert struct {
 		project  string
 		ancestry string
+		offline  bool
 	}
 	validate struct {
 		project    string
 		ancestry   string
+		offline    bool
 		policyPath string
 		outputJSON bool
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -43,10 +43,14 @@ Example:
 		if len(args) != 1 {
 			return errors.New("missing required argument <tfplan>")
 		}
+		if flags.validate.offline && flags.validate.ancestry == "" {
+			return errors.New("please set ancestry via --ancestry in offline mode")
+		}
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project, flags.validate.ancestry)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project,
+			flags.validate.ancestry, flags.validate.offline)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -31,10 +31,11 @@ import (
 )
 
 // ReadPlannedAssets extracts CAI assets from a terraform plan file.
-// If ancestry path is provided, it assumes the project is in that path rather
-// than fetching the ancestry information using Google API.
+// If ancestry path is provided, the ancestry cache will be prewarmed for the
+// project provided. If offline is set as true, it will avoid fetching resource
+// using Google API.
 // It ignores non-supported resources.
-func ReadPlannedAssets(path, project, ancestry string) ([]google.Asset, error) {
+func ReadPlannedAssets(path, project, ancestry string, offline bool) ([]google.Asset, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, errors.Wrap(err, "opening plan file")
@@ -54,15 +55,17 @@ func ReadPlannedAssets(path, project, ancestry string) ([]google.Asset, error) {
 		}
 	}
 
-	// Add User Agent string to indicate Terraform Validator usage.
-	// Do *NOT* change the "config-validator-tf/" prefix, or else it will
-	// break usage tracking.
-	ua := option.WithUserAgent(fmt.Sprintf("config-validator-tf/%s", BuildVersion()))
-	resourceManager, err := cloudresourcemanager.NewService(context.Background(), ua)
-	if err != nil {
-		return nil, errors.Wrap(err, "constructing resource manager client")
+	var resourceManager *cloudresourcemanager.Service
+	if !offline {
+		// Add User Agent string to indicate Terraform Validator usage.
+		// Do *NOT* change the "config-validator-tf/" prefix, or else it will
+		// break usage tracking.
+		ua := option.WithUserAgent(fmt.Sprintf("config-validator-tf/%s", BuildVersion()))
+		if resourceManager, err = cloudresourcemanager.NewService(context.Background(), ua); err != nil {
+			return nil, errors.Wrap(err, "constructing resource manager client")
+		}
 	}
-	converter, err := google.NewConverter(resourceManager, project, ancestry, "")
+	converter, err := google.NewConverter(resourceManager, project, ancestry, "", offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google converter")
 	}


### PR DESCRIPTION
The setup of resource manager client relies on Google OAuth library which would read the ADC json file and acquire a token, even if the client is not used in subsequent logic. I propose adding an offline flag so the client would not be setup for offline use case.