### PR TITLE
remove calling of cfg.LoadAndValidate

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -91,9 +91,6 @@ func NewConverter(resourceManager *cloudresourcemanager.Service, project, ancest
 		Project:     project,
 		Credentials: credentials,
 	}
-	if err := cfg.LoadAndValidate(); err != nil {
-		return nil, errors.Wrap(err, "configuring")
-	}
 
 	ancestryCache := make(map[string]string)
 	if ancestry != "" {


### PR DESCRIPTION
Based on discussion in #38, there is no need to call LoadAndValidate. In particular, the function perform OAuth dance which creates extra network dependencies.