### PR TITLE
Support Terraform 0.12 plan output for terraform-validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ credentials.json
 
 # Visual Studio Code
 .vscode/
+# Intellij Golang
+.idea/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ go install .
 
 See the [Auth](#Auth) section first.
 
+
+### Steps similar both for Terraform v0.11 and v0.12 versions
+
 ```
 # The example/ directory contains a basic Terraform config for testing the validator.
 cd example/
@@ -28,9 +31,33 @@ export POLICY_PATH=/path/to/your/forseti-config-policies/repo
 # Generate a terraform plan.
 terraform plan --out=terraform.tfplan
 
+```
+
+### Terraform v0.11
+
+```
 # Validate the google resources the plan would create.
 terraform-validator validate --policy-path=${POLICY_PATH} ./terraform.tfplan
 
+# Apply the validated plan.
+terraform apply ./terraform.tfplan
+```
+
+### Terraform v0.12
+
+For 0.12 Terraform release validator required plan exported in JSON format
+
+```
+# Plan JSON representation. 
+terraform show -json ./terraform.tfplan > ./terraform.tfplan.json
+
+# Validate the google resources the plan would create.
+terraform-validator validate --tf-version 0.12 --policy-path=${POLICY_PATH} ./terraform.tfplan.json
+```
+
+### Apply validated plan
+
+```
 # Apply the validated plan.
 terraform apply ./terraform.tfplan
 ```

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -46,7 +46,7 @@ Example:
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project, flags.convert.ancestry)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.convert.project, flags.convert.ancestry, flags.tfVersion)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,7 +46,7 @@ Example:
 		return nil
 	},
 	RunE: func(c *cobra.Command, args []string) error {
-		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project, flags.validate.ancestry)
+		assets, err := tfgcv.ReadPlannedAssets(args[0], flags.validate.project, flags.validate.ancestry, flags.tfVersion)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/test/convert_test.go
+++ b/test/convert_test.go
@@ -50,7 +50,7 @@ func TestConvert(t *testing.T) {
 	)
 
 	if err != nil {
-		t.Fatalf("%v:\n%v", err, errOutput)
+		t.Fatalf("%v:\n%v", err, string(errOutput))
 	}
 
 	var assets []google.Asset
@@ -113,7 +113,7 @@ func TestConvert(t *testing.T) {
 				t.Fatalf("binary return %v with stderr=%s, got %v, want %v", err, errOutput, gotError, tt.wantError)
 			}
 			if tt.wantOutputRegex != "" && !wantRe.Match(stdOutput) {
-				t.Fatalf("binary did not return expect output, got=%s\nwant (regex)=%s", stdOutput, tt.wantOutputRegex)
+				t.Fatalf("binary did not return expect output, got=%s\nwant (regex)=%s", string(stdOutput), tt.wantOutputRegex)
 			}
 		})
 	}

--- a/test/read_planned_assets/tf12plan.json
+++ b/test/read_planned_assets/tf12plan.json
@@ -1,0 +1,368 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.4",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_firewall.default",
+          "mode": "managed",
+          "type": "google_compute_firewall",
+          "name": "default",
+          "provider_name": "google",
+          "schema_version": 1,
+          "values": {
+            "allow": [
+              {
+                "ports": [
+                  "82",
+                  "8080",
+                  "1000-2000"
+                ],
+                "protocol": "tcp"
+              }
+            ],
+            "creation_timestamp": "2019-07-23T04:06:22.114-07:00",
+            "deny": [],
+            "description": "",
+            "destination_ranges": [],
+            "direction": "INGRESS",
+            "disabled": false,
+            "id": "test-firewall",
+            "name": "test-firewall",
+            "network": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/networks/default",
+            "priority": 1000,
+            "project": "gl-akopachevskyy-sql-db",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/firewalls/test-firewall",
+            "source_ranges": [],
+            "source_service_accounts": [],
+            "source_tags": [
+              "web"
+            ],
+            "target_service_accounts": [],
+            "target_tags": [],
+            "timeouts": null
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.mymodule.google_compute_firewall.http",
+              "mode": "managed",
+              "type": "google_compute_firewall",
+              "name": "http",
+              "provider_name": "google",
+              "schema_version": 1,
+              "values": {
+                "allow": [
+                  {
+                    "ports": [
+                      "8181"
+                    ],
+                    "protocol": "udp"
+                  }
+                ],
+                "deny": [],
+                "description": null,
+                "disabled": null,
+                "name": "server-fiewall",
+                "network": "default",
+                "priority": 1000,
+                "source_service_accounts": null,
+                "source_tags": [
+                  "server"
+                ],
+                "target_service_accounts": null,
+                "target_tags": null,
+                "timeouts": null
+              }
+            }
+          ],
+          "address": "module.mymodule"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_firewall.default",
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "default",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "allow": [
+            {
+              "ports": [
+                "82",
+                "8080",
+                "1000-2000"
+              ],
+              "protocol": "tcp"
+            }
+          ],
+          "creation_timestamp": "2019-07-23T04:06:22.114-07:00",
+          "deny": [],
+          "description": "",
+          "destination_ranges": [],
+          "direction": "INGRESS",
+          "disabled": false,
+          "id": "test-firewall",
+          "name": "test-firewall",
+          "network": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/networks/default",
+          "priority": 1000,
+          "project": "gl-akopachevskyy-sql-db",
+          "self_link": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/firewalls/test-firewall",
+          "source_ranges": [],
+          "source_service_accounts": [],
+          "source_tags": [
+            "web"
+          ],
+          "target_service_accounts": [],
+          "target_tags": [],
+          "timeouts": null
+        },
+        "after": {
+          "allow": [
+            {
+              "ports": [
+                "82",
+                "8080",
+                "1000-2000"
+              ],
+              "protocol": "tcp"
+            }
+          ],
+          "creation_timestamp": "2019-07-23T04:06:22.114-07:00",
+          "deny": [],
+          "description": "",
+          "destination_ranges": [],
+          "direction": "INGRESS",
+          "disabled": false,
+          "id": "test-firewall",
+          "name": "test-firewall",
+          "network": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/networks/default",
+          "priority": 1000,
+          "project": "gl-akopachevskyy-sql-db",
+          "self_link": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/firewalls/test-firewall",
+          "source_ranges": [],
+          "source_service_accounts": [],
+          "source_tags": [
+            "web"
+          ],
+          "target_service_accounts": [],
+          "target_tags": [],
+          "timeouts": null
+        },
+        "after_unknown": {}
+      }
+    },
+    {
+      "address": "module.mymodule.google_compute_firewall.http",
+      "module_address": "module.mymodule",
+      "mode": "managed",
+      "type": "google_compute_firewall",
+      "name": "http",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "allow": [
+            {
+              "ports": [
+                "8181"
+              ],
+              "protocol": "udp"
+            }
+          ],
+          "deny": [],
+          "description": null,
+          "disabled": null,
+          "name": "server-fiewall",
+          "network": "default",
+          "priority": 1000,
+          "source_service_accounts": null,
+          "source_tags": [
+            "server"
+          ],
+          "target_service_accounts": null,
+          "target_tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "allow": [
+            {
+              "ports": [
+                false
+              ]
+            }
+          ],
+          "creation_timestamp": true,
+          "deny": [],
+          "destination_ranges": true,
+          "direction": true,
+          "id": true,
+          "project": true,
+          "self_link": true,
+          "source_ranges": true,
+          "source_tags": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "prior_state": {
+    "format_version": "0.1",
+    "terraform_version": "0.12.4",
+    "values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "google_compute_firewall.default",
+            "mode": "managed",
+            "type": "google_compute_firewall",
+            "name": "default",
+            "provider_name": "google",
+            "schema_version": 1,
+            "values": {
+              "allow": [
+                {
+                  "ports": [
+                    "82",
+                    "8080",
+                    "1000-2000"
+                  ],
+                  "protocol": "tcp"
+                }
+              ],
+              "creation_timestamp": "2019-07-23T04:06:22.114-07:00",
+              "deny": [],
+              "description": "",
+              "destination_ranges": [],
+              "direction": "INGRESS",
+              "disabled": false,
+              "id": "test-firewall",
+              "name": "test-firewall",
+              "network": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/networks/default",
+              "priority": 1000,
+              "project": "gl-akopachevskyy-sql-db",
+              "self_link": "https://www.googleapis.com/compute/v1/projects/gl-akopachevskyy-sql-db/global/firewalls/test-firewall",
+              "source_ranges": [],
+              "source_service_accounts": [],
+              "source_tags": [
+                "web"
+              ],
+              "target_service_accounts": [],
+              "target_tags": [],
+              "timeouts": null
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "version_constraint": "~\u003e 2.5",
+        "expressions": {
+          "project": {
+            "constant_value": "gl-akopachevskyy-sql-db"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_firewall.default",
+          "mode": "managed",
+          "type": "google_compute_firewall",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "allow": [
+              {
+                "ports": {
+                  "constant_value": [
+                    "82",
+                    "8080",
+                    "1000-2000"
+                  ]
+                },
+                "protocol": {
+                  "constant_value": "tcp"
+                }
+              }
+            ],
+            "name": {
+              "constant_value": "test-firewall"
+            },
+            "network": {
+              "constant_value": "default"
+            },
+            "source_tags": {
+              "constant_value": [
+                "web"
+              ]
+            }
+          },
+          "schema_version": 1
+        }
+      ],
+      "module_calls": {
+        "mymodule": {
+          "source": "./module",
+          "module": {
+            "resources": [
+              {
+                "address": "google_compute_firewall.http",
+                "mode": "managed",
+                "type": "google_compute_firewall",
+                "name": "http",
+                "provider_config_key": "mymodule:google",
+                "expressions": {
+                  "allow": [
+                    {
+                      "ports": {
+                        "constant_value": [
+                          "8181"
+                        ]
+                      },
+                      "protocol": {
+                        "constant_value": "udp"
+                      }
+                    }
+                  ],
+                  "name": {
+                    "constant_value": "server-fiewall"
+                  },
+                  "network": {
+                    "constant_value": "default"
+                  },
+                  "source_tags": {
+                    "constant_value": [
+                      "server"
+                    ]
+                  }
+                },
+                "schema_version": 1
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tfgcv/planned_assets_test.go
+++ b/tfgcv/planned_assets_test.go
@@ -1,0 +1,62 @@
+package tfgcv
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
+)
+
+const TF11PLAN string = "../test/read_planned_assets/tf11plan.tfplan"
+const TF12PLAN string = "../test/read_planned_assets/tf12plan.json"
+
+func TestReadPlannedAssets(t *testing.T) {
+	type args struct {
+		path      string
+		project   string
+		ancestry  string
+		tfVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			"Test TF12 and JSON plan",
+			args{TF12PLAN, "prj", "ancsetry", tfplan.TF12},
+			2,
+			false,
+		},
+		{
+			"Test TF12 and binary plan",
+			args{TF12PLAN, "prj", "ancsetry", tfplan.TF11},
+			0,
+			true,
+		},
+		{
+			"Test TF11 and JSON plan",
+			args{TF11PLAN, "prj", "ancsetry", tfplan.TF12},
+			0,
+			true,
+		},
+		{
+			"Test TF11 and binary plan",
+			args{TF12PLAN, "prj", "ancsetry", tfplan.TF12},
+			2,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadPlannedAssets(tt.args.path, tt.args.project, tt.args.ancestry, tt.args.tfVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadPlannedAssets() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != tt.want {
+				t.Errorf("ReadPlannedAssets() = %v, want %v", len(got), tt.want)
+			}
+		})
+	}
+}

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -1,0 +1,175 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tfplan
+
+import (
+	"bytes"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pkg/errors"
+)
+
+// jsonPlan structure used to parse Terraform 12 plan exported in json format by 'terraform show -json ./binary_plan.tfplan' command.
+type jsonPlan struct {
+	PlannedValues struct {
+		RootModules struct {
+			Resources    []jsonResource
+			ChildModules []struct {
+				Address   string
+				Resources []jsonResource
+			} `json:"child_modules"`
+		} `json:"root_module"`
+	} `json:"planned_values"`
+}
+
+// jsonResource represent single Terraform resource definition.
+type jsonResource struct {
+	Module       string
+	Name         string
+	Address      string
+	Mode         string
+	Kind         string `json:"type"`
+	ProviderName string `json:"provider_name"`
+	Values       map[string]interface{}
+}
+
+// jsonResourceFieldReader structure used to search retrieve fields from jsonResource.Values map of maps.
+type jsonResourceFieldReader struct {
+	Source jsonResource
+	Schema map[string]*schema.Schema
+}
+
+// ComposeTF12Resources inspects a plan and returns the planned resources that match the provided resource schema map.
+// ComposeTF12Resources works in a same way as tfplan.ComposeResources and returns array of tfplan.Resource
+func ComposeTF12Resources(data []byte, schemas map[string]*schema.Resource) ([]Resource, error) {
+	resources, err := readJSONResources(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "read resources")
+	}
+
+	var instances []Resource
+	for _, r := range resources {
+		sch, ok := schemas[r.Kind]
+		if !ok {
+			// Unsupported in given provider schema.
+			continue
+		}
+
+		instances = append(instances, Resource{
+			Path:        Fullpath{r.Kind, r.Name, r.Module},
+			fieldGetter: newJSONFieldGetter(sch.Schema, r),
+		})
+	}
+	return instances, nil
+}
+
+// ReadField are responsible for decoding fields out of data into
+// the proper typed representation. jsonResourceFieldReader uses this to query data from json representation of
+// Terraform 12 plan.
+// See github.com/hashicorp/terraform/helper/schema.FieldReader interface for details
+func (r jsonResourceFieldReader) ReadField(address []string) (schema.FieldReadResult, error) {
+	addr := strings.Join(address, ".")
+	schemaList := jsonAddrToSchema(address, r.Schema)
+	if len(schemaList) == 0 {
+		return schema.FieldReadResult{}, nil
+	}
+
+	var returnVal interface{}
+	sch := schemaList[len(schemaList)-1]
+	switch sch.Type {
+	case schema.TypeBool, schema.TypeInt, schema.TypeFloat, schema.TypeString:
+		returnVal = r.Source.Values[addr]
+	case schema.TypeSet:
+		value := r.Source.Values[addr]
+		if value == nil {
+			if sch.Default != nil {
+				value = sch.Default
+			} else {
+				value = []interface{}{}
+			}
+		}
+		f := hashInterface
+		returnVal = schema.NewSet(f, value.([]interface{}))
+	default:
+		panic(fmt.Sprintf("Unknown type: %s", sch.Type))
+	}
+	return schema.FieldReadResult{
+		Value:  returnVal,
+		Exists: returnVal != nil,
+	}, nil
+}
+
+// readJSONResources unmarshal json data to go struct
+// and returns array of all jsonResources both from root and child modules.
+func readJSONResources(data []byte) ([]jsonResource, error) {
+	plan := jsonPlan{}
+	err := json.Unmarshal(data, &plan)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var result []jsonResource
+
+	for _, resource := range plan.PlannedValues.RootModules.Resources {
+		resource.Module = "root"
+		result = append(result, resource)
+	}
+
+	for _, module := range plan.PlannedValues.RootModules.ChildModules {
+		name := strings.SplitAfterN(module.Address, ".", 2)[1]
+		for _, resource := range module.Resources {
+			resource.Module = name
+			result = append(result, resource)
+		}
+	}
+
+	return result, nil
+}
+
+func newJSONFieldGetter(sch map[string]*schema.Schema, resource jsonResource) *fieldGetter {
+	return &fieldGetter{
+		rdr:    jsonResourceFieldReader{resource, sch},
+		schema: sch,
+	}
+}
+
+// jsonAddrToSchema returns shema.Shema object for string address representation, in most common case address is just
+func jsonAddrToSchema(addr []string, schemaMap map[string]*schema.Schema) []*schema.Schema {
+	var result []*schema.Schema
+	key := strings.Join(addr, ".")
+	result = append(result, schemaMap[key])
+	return result
+}
+
+// Function hashInterface returns unique in ID for any given object.
+// Function used by schema.Set instance, see github.com/hashicorp/terraform/helper/schema.SchemaSetFunc type for details.
+func hashInterface(s interface{}) int {
+	var b bytes.Buffer
+	err := gob.NewEncoder(&b).Encode(s)
+	if err != nil {
+		panic(fmt.Sprintf("error creating hashInterface function: %v", err))
+	}
+	h := fnv.New32a()
+	_, err = h.Write(b.Bytes())
+	if err != nil {
+		panic(fmt.Sprintf("error creating hashInterface function: %v", err))
+	}
+	return int(h.Sum32())
+}

--- a/tfplan/json_plan_test.go
+++ b/tfplan/json_plan_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tfplan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func Test_jsonResourceFieldReader_ReadField(t *testing.T) {
+	type fields struct {
+		Name  string
+		Value interface{}
+		Type  schema.ValueType
+	}
+	type args struct {
+		address string
+	}
+	type want struct {
+		Value interface{}
+		Found bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    want
+		wantErr bool
+	}{
+		{
+			"string",
+			fields{"name", "string_value", schema.TypeString},
+			args{"name"},
+			want{"string_value", true},
+			false,
+		},
+		{
+			"bool",
+			fields{"name", "true", schema.TypeBool},
+			args{"name"},
+			want{"true", true},
+			false,
+		},
+		{
+			"set",
+			fields{"name", []interface{}{"1", "2"}, schema.TypeSet},
+			args{"name"},
+			want{[]interface{}{"2", "1"}, true},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := jsonResourceFieldReader{
+				Source: createResource(tt.fields.Name, tt.fields.Value),
+				Schema: createSchemaMap(tt.args.address, tt.fields.Type),
+			}
+			address := []string{tt.args.address}
+			got, err := r.ReadField(address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jsonResourceFieldReader.ReadField() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			switch got.Value.(type) {
+			case *schema.Set:
+				tmpVal := got.Value.(*schema.Set)
+				got.Value = tmpVal.List()
+			}
+			if !reflect.DeepEqual(got.Value, tt.want.Value) {
+				t.Errorf("jsonResourceFieldReader.ReadField() = %v, want %v", got.Value, tt.want.Value)
+			}
+
+		})
+	}
+}
+
+func createSchemaMap(address string, valueType schema.ValueType) map[string]*schema.Schema {
+	result := map[string]*schema.Schema{}
+	result[address] = &schema.Schema{Type: valueType}
+	return result
+}
+
+func createResource(address string, value interface{}) jsonResource {
+	values := map[string]interface{}{}
+	values[address] = value
+	return jsonResource{Values: values}
+}

--- a/tfplan/plan.go
+++ b/tfplan/plan.go
@@ -21,6 +21,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+const (
+	TF11 string = "0.11"
+	TF12 string = "0.12"
+)
+
 // Resource is the terraform representation of a resource.
 type Resource struct {
 	Path Fullpath
@@ -45,15 +50,15 @@ func (r *Resource) Provider() string {
 func ComposeResources(plan *terraform.Plan, schemas map[string]*schema.Resource) []Resource {
 	instances := make([]Resource, 0)
 	for path, sd := range mergeStateDiffs(plan) {
-		schema, ok := schemas[path.Kind]
+		schm, ok := schemas[path.Kind]
 		if !ok {
-			// Unsupported in given provider schema.
+			// Unsupported in given provider schm.
 			continue
 		}
 
 		instances = append(instances, Resource{
 			Path:        path,
-			fieldGetter: newFieldGetter(schema.Schema, sd.State, sd.Diff),
+			fieldGetter: newFieldGetter(schm.Schema, sd.State, sd.Diff),
 		})
 	}
 


### PR DESCRIPTION
Fixes #12
Terraform v0.12 validation implemented by reading plan file exported to JSON format and converting it to CAI format by creating custom FieldReader. 

Terraform validator CLI arguments does not changed, but if you pass .json file to "validate" command it will treat it as tf v0.12 version json file.

"convert" command also support TF12 as long it uses same code base as "validate"