### PR TITLE
Fix/add support bucket policy only

### DIFF
--- a/vendor/github.com/GoogleCloudPlatform/terraform-google-conversion/google/storage_bucket.go
+++ b/vendor/github.com/GoogleCloudPlatform/terraform-google-conversion/google/storage_bucket.go
@@ -183,7 +183,7 @@ func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {
 	return bucketVersioning
 }
 
-func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfiguration {
+func expandIamConfiguration(d TerraformResourceData) *storage.BucketIamConfiguration {
 	return &storage.BucketIamConfiguration{
 		ForceSendFields: []string{"BucketPolicyOnly"},
 		BucketPolicyOnly: &storage.BucketIamConfigurationBucketPolicyOnly{

--- a/vendor/github.com/GoogleCloudPlatform/terraform-google-conversion/google/storage_bucket.go
+++ b/vendor/github.com/GoogleCloudPlatform/terraform-google-conversion/google/storage_bucket.go
@@ -53,6 +53,7 @@ func GetStorageBucketApiObject(d TerraformResourceData, config *Config) (map[str
 		Name:     bucket,
 		Labels:   expandLabels(d),
 		Location: location,
+		IamConfiguration: expandIamConfiguration(d),
 	}
 
 	if v, ok := d.GetOk("storage_class"); ok {
@@ -180,6 +181,16 @@ func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {
 	bucketVersioning.ForceSendFields = append(bucketVersioning.ForceSendFields, "Enabled")
 
 	return bucketVersioning
+}
+
+func expandIamConfiguration(d *schema.ResourceData) *storage.BucketIamConfiguration {
+	return &storage.BucketIamConfiguration{
+		ForceSendFields: []string{"BucketPolicyOnly"},
+		BucketPolicyOnly: &storage.BucketIamConfigurationBucketPolicyOnly{
+			Enabled:         d.Get("bucket_policy_only").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
+	}
 }
 
 func resourceGCSBucketLifecycleCreateOrUpdate(d TerraformResourceData, sb *storage.Bucket) error {


### PR DESCRIPTION
The source file [resource_storage_bucket.go](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/third_party/terraform/resources/resource_storage_bucket.go) was updated a while back to add support for **bucket_policy_only**. Here, the corresponding files in vendor are modified to reflect such update. Now terraform-validator can support constraint `storage_bucket_policy_only.yaml`. The initial issue can be referred here #53 