### PR TITLE
allow policy and lib from a different parent folder

### DIFF
--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -32,11 +32,19 @@ func BuildVersion() string {
 	return buildVersion
 }
 
-// ValidateAssets instantiates GCV and audits CAI assets.
+// ValidateAssets instantiates GCV and audits CAI assets using "policies"
+// and "lib" folder under policyPath.
 func ValidateAssets(assets []google.Asset, policyPath string) (*validator.AuditResponse, error) {
+	return ValidateAssetsWithLibrary(assets,
+		filepath.Join(policyPath, "policies"),
+		filepath.Join(policyPath, "lib"))
+}
+
+// ValidateAssetsWithLibrary instantiates GCV and audits CAI assets.
+func ValidateAssetsWithLibrary(assets []google.Asset, policyPath, policyLibraryDir string) (*validator.AuditResponse, error) {
 	valid, err := gcv.NewValidator(
-		gcv.PolicyPath(filepath.Join(policyPath, "policies")),
-		gcv.PolicyLibraryDir(filepath.Join(policyPath, "lib")),
+		gcv.PolicyPath(policyPath),
+		gcv.PolicyLibraryDir(policyLibraryDir),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "initializing gcv validator")

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -33,11 +33,11 @@ func BuildVersion() string {
 }
 
 // ValidateAssets instantiates GCV and audits CAI assets using "policies"
-// and "lib" folder under policyPath.
-func ValidateAssets(assets []google.Asset, policyPath string) (*validator.AuditResponse, error) {
+// and "lib" folder under policyRootPath.
+func ValidateAssets(assets []google.Asset, policyRootPath string) (*validator.AuditResponse, error) {
 	return ValidateAssetsWithLibrary(assets,
-		filepath.Join(policyPath, "policies"),
-		filepath.Join(policyPath, "lib"))
+		filepath.Join(policyRootPath, "policies"),
+		filepath.Join(policyRootPath, "lib"))
 }
 
 // ValidateAssetsWithLibrary instantiates GCV and audits CAI assets.


### PR DESCRIPTION
A small refactor to allow using a shared library folder and a policy folder that does not share a common parent directory.

I created `ValidateAssetsWithLibrary` as a new function because `ValidateAssets` is an exported function and I don't want to modify the function arguments as that would create a breaking change.