### PR TITLE
extract ancestry discovery logic into an interface

### DIFF
--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -1,0 +1,77 @@
+// Package ancestrymanager provides an interface to query the ancestry information for a project.
+package ancestrymanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/option"
+)
+
+// AncestryManager is the interface that wraps the GetAncestry method.
+type AncestryManager interface {
+	// GetAncestry takes a project name and return a ancestry path
+	GetAncestry(project string) (string, error)
+}
+
+type ancestryManager struct {
+	// Talk to GCP resource manager. This field would be nil in offline mode.
+	resourceManager *cloudresourcemanager.Service
+	// Cache to prevent multiple network calls for looking up the same project's ancestry
+	// map[project]ancestryPath
+	ancestryCache map[string]string
+}
+
+// GetAncestry uses the resource manager API to get ancestry paths for
+// projects. It implements a cache because many resources share the same
+// project.
+func (am *ancestryManager) GetAncestry(project string) (string, error) {
+	if path, ok := am.ancestryCache[project]; ok {
+		return path, nil
+	}
+	if am.resourceManager == nil {
+		return "", fmt.Errorf("cannot fetch ancestry in offline mode for project %s", project)
+	}
+	ancestry, err := am.resourceManager.Projects.GetAncestry(project, &cloudresourcemanager.GetAncestryRequest{}).Do()
+	if err != nil {
+		return "", err
+	}
+	path := ancestryPath(ancestry.Ancestor)
+	am.store(project, path)
+	return path, nil
+}
+
+func (am *ancestryManager) store(project, ancestry string) {
+	if project != "" && ancestry != "" {
+		am.ancestryCache[project] = ancestry
+	}
+}
+
+// New returns AncestryManager that can be used to fetch ancestry information for a project.
+func New(ctx context.Context, project, ancestry string, offline bool, opts ...option.ClientOption) (AncestryManager, error) {
+	am := &ancestryManager{
+		ancestryCache: map[string]string{},
+	}
+	am.store(project, ancestry)
+	if !offline {
+		rm, err := cloudresourcemanager.NewService(ctx, opts...)
+		if err != nil {
+			return nil, errors.Wrap(err, "constructing resource manager client")
+		}
+		am.resourceManager = rm
+	}
+	return am, nil
+}
+
+// ancestryPath composes a path containing organization/folder/project
+// (i.e. "organization/my-org/folder/my-folder/project/my-prj").
+func ancestryPath(as []*cloudresourcemanager.Ancestor) string {
+	var path []string
+	for i := len(as) - 1; i >= 0; i-- {
+		path = append(path, as[i].ResourceId.Type, as[i].ResourceId.Id)
+	}
+	return strings.Join(path, "/")
+}

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -1,0 +1,133 @@
+package ancestrymanager
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/option"
+)
+
+func TestAncestryPath(t *testing.T) {
+	cases := []struct {
+		name           string
+		input          []*cloudresourcemanager.Ancestor
+		expectedOutput string
+	}{
+		{
+			name:           "Empty",
+			input:          []*cloudresourcemanager.Ancestor{},
+			expectedOutput: "",
+		},
+		{
+			name: "ProjectOrganization",
+			input: []*cloudresourcemanager.Ancestor{
+				{
+					ResourceId: &cloudresourcemanager.ResourceId{
+						Id:   "my-prj",
+						Type: "project",
+					},
+				},
+				{
+					ResourceId: &cloudresourcemanager.ResourceId{
+						Id:   "my-org",
+						Type: "organization",
+					},
+				},
+			},
+			expectedOutput: "organization/my-org/project/my-prj",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			output := ancestryPath(c.input)
+			if output != c.expectedOutput {
+				t.Errorf("expected output %q, got %q", c.expectedOutput, output)
+			}
+		})
+	}
+}
+
+func TestGetAncestry(t *testing.T) {
+	ctx := context.Background()
+	ownerProject := "foo"
+	ownerAncestry := "organization/qux/folder/bar/project/foo"
+	anotherProject := "foo2"
+
+	// Setup a simple test server to mock the response of resource manager.
+	cache := map[string][]*cloudresourcemanager.Ancestor{
+		ownerProject: []*cloudresourcemanager.Ancestor{
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "foo", Type: "project"}},
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "bar", Type: "folder"}},
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "qux", Type: "organization"}},
+		},
+		anotherProject: []*cloudresourcemanager.Ancestor{
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "foo2", Type: "project"}},
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "bar2", Type: "folder"}},
+			{ResourceId: &cloudresourcemanager.ResourceId{Id: "qux2", Type: "organization"}},
+		},
+	}
+	ts := newAncestryManagerMockServer(t, cache)
+	defer ts.Close()
+
+	amOnline, err := New(ctx, ownerProject, "", false, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("failed to create online ancestry manager: %s", err)
+	}
+	amOffline, err := New(ctx, ownerProject, ownerAncestry, true)
+	if err != nil {
+		t.Fatalf("failed to create offline ancestry manager: %s", err)
+	}
+
+	cases := []struct {
+		name      string
+		target    AncestryManager
+		query     string
+		wantError bool
+		want      string
+	}{
+		{name: "owner_project_online", target: amOnline, query: ownerProject, want: ownerAncestry},
+		{name: "owner_project_offline", target: amOffline, query: ownerProject, want: ownerAncestry},
+		{name: "another_project_online", target: amOnline, query: anotherProject, want: "organization/qux2/folder/bar2/project/foo2"},
+		{name: "another_project_offline", target: amOffline, query: anotherProject, wantError: true},
+		{name: "missed_project_online", target: amOnline, query: "notexist", wantError: true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := c.target.GetAncestry(c.query)
+			if !c.wantError && err != nil {
+				t.Fatalf("GetAncestry(%s) returns error: %s", c.query, err)
+			}
+			if c.wantError && err == nil {
+				t.Fatalf("GetAncestry(%s) returns no error, want error", c.query)
+			}
+			if got != c.want {
+				t.Errorf("GetAncestry(%s): got=%s, want=%s", c.query, got, c.want)
+			}
+		})
+	}
+}
+
+func newAncestryManagerMockServer(t *testing.T, cache map[string][]*cloudresourcemanager.Ancestor) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		re := regexp.MustCompile(`([^/]*):getAncestry`)
+		path := re.FindStringSubmatch(r.URL.Path)
+		if path == nil || cache[path[1]] == nil {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		payload, err := (&cloudresourcemanager.GetAncestryResponse{Ancestor: cache[path[1]]}).MarshalJSON()
+		if err != nil {
+			t.Errorf("failed to MarshalJSON: %s", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write(payload)
+	}))
+	return ts
+}

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -19,49 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/api/cloudresourcemanager/v1"
 )
-
-func TestAncestryPath(t *testing.T) {
-	cases := []struct {
-		name           string
-		input          []*cloudresourcemanager.Ancestor
-		expectedOutput string
-	}{
-		{
-			name:           "Empty",
-			input:          []*cloudresourcemanager.Ancestor{},
-			expectedOutput: "",
-		},
-		{
-			name: "ProjectOrganization",
-			input: []*cloudresourcemanager.Ancestor{
-				{
-					ResourceId: &cloudresourcemanager.ResourceId{
-						Id:   "my-prj",
-						Type: "project",
-					},
-				},
-				{
-					ResourceId: &cloudresourcemanager.ResourceId{
-						Id:   "my-org",
-						Type: "organization",
-					},
-				},
-			},
-			expectedOutput: "organization/my-org/project/my-prj",
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			output := ancestryPath(c.input)
-			if output != c.expectedOutput {
-				t.Errorf("expected output %q, got %q", c.expectedOutput, output)
-			}
-		})
-	}
-}
 
 func TestSortByName(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
This fixes #75 with a small change of scope. Instead of making converter an interface, this creates a new interface called AncestryManager which has a GetAncestry method. 

The implementation for online mode uses resource manager and a cache. This works the same way as when --offline=false. 

Test has been added with a mock of resource manager API server for GetAncestry call.

Also, the need of calling `converter.LoadAndValidate()` is removed as the upstream dependency (`terraform_google_conversion`) do not requires the clients to be constructed for the TF module supported. Please review that as well.

I would also like to get help to see if the names for the interface and methods make sense. I cannot make up a better name.
