### PR TITLE
ancestrymanager should take ancestry without the project

### DIFF
--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -63,6 +63,9 @@ func (m *offlineAncestryManager) GetAncestry(project string) (string, error) {
 
 // New returns AncestryManager that can be used to fetch ancestry information for a project.
 func New(ctx context.Context, project, ancestry string, offline bool, opts ...option.ClientOption) (AncestryManager, error) {
+	if ancestry != "" {
+		ancestry = fmt.Sprintf("%s/project/%s", ancestry, project)
+	}
 	if offline {
 		return &offlineAncestryManager{project: project, ancestry: ancestry}, nil
 	}

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -55,7 +55,8 @@ func TestAncestryPath(t *testing.T) {
 func TestGetAncestry(t *testing.T) {
 	ctx := context.Background()
 	ownerProject := "foo"
-	ownerAncestry := "organization/qux/folder/bar/project/foo"
+	ownerAncestry := "organization/qux/folder/bar"
+	ownerAncestryPath := "organization/qux/folder/bar/project/foo"
 	anotherProject := "foo2"
 
 	// Setup a simple test server to mock the response of resource manager.
@@ -90,8 +91,8 @@ func TestGetAncestry(t *testing.T) {
 		wantError bool
 		want      string
 	}{
-		{name: "owner_project_online", target: amOnline, query: ownerProject, want: ownerAncestry},
-		{name: "owner_project_offline", target: amOffline, query: ownerProject, want: ownerAncestry},
+		{name: "owner_project_online", target: amOnline, query: ownerProject, want: ownerAncestryPath},
+		{name: "owner_project_offline", target: amOffline, query: ownerProject, want: ownerAncestryPath},
 		{name: "another_project_online", target: amOnline, query: anotherProject, want: "organization/qux2/folder/bar2/project/foo2"},
 		{name: "another_project_offline", target: amOffline, query: anotherProject, wantError: true},
 		{name: "missed_project_online", target: amOnline, query: "notexist", wantError: true},


### PR DESCRIPTION
The logic on adding project name onto the ancestry value taken from command line flag is missing.

The original logic before ancestrymanager is introduced can be found here: https://github.com/GoogleCloudPlatform/terraform-validator/commit/a4c08567f77608a33d09ed1dee0b16600f3304b3#diff-747eeb1f3694357a501140221061b33eR114

```
if ancestry != "" {
	ancestryCache[project] = fmt.Sprintf("%s/project/%s", ancestry, project)
}
```