### PR TITLE
use -mod=vendor in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,19 +14,19 @@ prepare-v11:
 
 test:
 	# Skip integration tests in ./test/
-	GO111MODULE=on go test -tags=$(BUILDTAGS) `go list -tags=$(BUILDTAGS) ./... | grep -v terraform-validator/test`
+	GO111MODULE=on go test -mod=vendor -tags=$(BUILDTAGS) `go list -mod=vendor -tags=$(BUILDTAGS) ./... | grep -v terraform-validator/test`
 
 run-docker:
 	docker run -it -v `pwd`:/terraform-validator -v ${GOOGLE_APPLICATION_CREDENTIALS}:/terraform-validator/credentials.json --entrypoint=/bin/bash --env TEST_PROJECT=${PROJECT_ID} --env TEST_CREDENTIALS=./credentials.json terraform-validator;
 
 test-integration:
-	go test -tags=$(BUILDTAGS) -v ./test
+	go test -mod=vendor -tags=$(BUILDTAGS) -v ./test
 
 build-docker:
 	docker build -f ./Dockerfile -t terraform-validator .
 
 build:
-	GO111MODULE=on go build -tags=$(BUILDTAGS) -ldflags ${LDFLAGS} -mod=vendor -o ${BUILD_DIR}/${NAME}
+	GO111MODULE=on go build -mod=vendor -tags=$(BUILDTAGS) -ldflags ${LDFLAGS} -o ${BUILD_DIR}/${NAME}
 
 release: $(PLATFORMS)
 
@@ -34,7 +34,7 @@ publish:
 	gsutil cp ${BUILD_DIR}/*-amd64 gs://${RELEASE_BUCKET}/releases/${DATE}
 
 $(PLATFORMS):
-	GO111MODULE=on GOOS=$@ GOARCH=amd64 CGO_ENABLED=0 go build -tags=$(BUILDTAGS) -mod=vendor -ldflags ${LDFLAGS} -o "${BUILD_DIR}/${NAME}-$@-amd64" .
+	GO111MODULE=on GOOS=$@ GOARCH=amd64 CGO_ENABLED=0 go build -mod=vendor -tags=$(BUILDTAGS) -ldflags ${LDFLAGS} -o "${BUILD_DIR}/${NAME}-$@-amd64" .
 
 clean:
 	rm bin/${NAME}*


### PR DESCRIPTION
The build is not using vendor directory and that make every build spent more than 2 minutes just on downloading dependencies in Cloud Build. 

I also suspect that the -mod flag needs to be provided before other flags. 