### PR TITLE
Remove noisy printing of "[INFO] Failed to retrieve project_id"

### DIFF
--- a/converters/google/vendor_utils.go
+++ b/converters/google/vendor_utils.go
@@ -38,8 +38,6 @@ func getProject(d converter.TerraformResourceData, config *converter.Config, cai
 		}
 	}
 
-	log.Printf("[INFO] Failed to retrieve project_id for %s from resource", cai.Name)
-
 	return getProjectFromSchema("project", d, config)
 }
 


### PR DESCRIPTION
The error is very misleading. The project_id is identified on the resource.