### PR TITLE
Add support for Spanner Instance to Terraform Validator.

### DIFF
--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -54,6 +54,7 @@ func mappers() map[string][]mapper {
 		"google_container_cluster":     {{convert: converter.GetContainerClusterCaiObject}},
 		"google_container_node_pool":   {{convert: converter.GetContainerNodePoolCaiObject}},
 		"google_bigquery_dataset":      {{convert: converter.GetBigQueryDatasetCaiObject}},
+		"google_spanner_instance":      {{convert: converter.GetSpannerInstanceCaiObject}},
 
 		// Terraform resources of type "google_project" have a 1:N relationship with CAI assets.
 		"google_project": {

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -45,6 +45,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "full_container_cluster"},
 		{name: "full_container_node_pool"},
 		{name: "full_sql_database_instance"},
+		{name: "full_spanner_instance"},
 		{name: "full_storage_bucket"},
 	}
 	for i := range cases {

--- a/testdata/templates/full_spanner_instance.json
+++ b/testdata/templates/full_spanner_instance.json
@@ -1,0 +1,26 @@
+[
+{
+  "name": "//spanner.googleapis.com/projects/{{.Provider.project}}/instances/spanner-instance",
+  "asset_type": "spanner.googleapis.com/Instance",
+  "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+  "resource": {
+    "version": "v1",
+    "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/spanner/v1/rest",
+    "discovery_name": "Instance",
+    "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+    "data": {
+      "instance": {
+        "config": "projects/{{.Provider.project}}/instanceConfigs/regional-us-central1",
+        "displayName": "spanner-instance",
+        "labels": {
+          "label1": "value1",
+          "label2": "value2",
+          "label3": "value3"
+        },
+        "nodeCount": 1
+      },
+      "instanceId": "spanner-instance"
+      }
+  }
+}
+]

--- a/testdata/templates/full_spanner_instance.tf
+++ b/testdata/templates/full_spanner_instance.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google" {
+  version     = "~> {{.Provider.version}}"
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+
+resource "google_spanner_instance" "spanner-instance" {
+  name         = "spanner-instance"
+  display_name = "spanner-instance"
+  config       = "regional-us-central1"
+  num_nodes    = 1
+
+  labels = {
+    label1   = "value1"
+    label2   = "value2"
+    label3   = "value3"
+  }
+}

--- a/testdata/templates/full_spanner_instance.tfplan.json
+++ b/testdata/templates/full_spanner_instance.tfplan.json
@@ -1,0 +1,76 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.13",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+            {
+              "address": "module.env.google_spanner_instance.spanner-instance",
+              "mode": "managed",
+              "type": "google_spanner_instance",
+              "name": "spanner-instance",
+              "provider_name": "google",
+              "schema_version": 0,
+              "values": {
+                "config": "projects/{{.Provider.project}}/instanceConfigs/regional-us-central1",
+                "display_name": "spanner-instance",
+                "id": "{{.Provider.project}}/spanner-instance",
+                "labels": {
+                  "label1": "value1",
+                  "label2": "value2",
+                  "label3": "value3"
+                },
+                "name": "spanner-instance",
+                "num_nodes": 1,
+                "state": "READY",
+                "timeouts": null
+              }
+            }
+          ]
+        }
+    },
+  "resource_changes": [
+     {
+      "address": "module.env.google_spanner_instance.spanner-instance",
+      "module_address": "module.env",
+      "mode": "managed",
+      "type": "google_spanner_instance",
+      "name": "spanner-instance",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "config": "projects/abcloud-ref-dev/instanceConfigs/regional-us-central1",
+          "display_name": "spanner-instance",
+          "id": "{{.Provider.project}}/spanner-instance",
+          "labels": {
+            "label1": "value1",
+            "label2": "value2",
+            "label3": "value3"
+          },
+          "name": "spanner-instance",
+          "num_nodes": 1,
+          "state": "READY",
+          "timeouts": null
+        },
+        "after": {
+          "config": "projects/{{.Provider.project}}/instanceConfigs/regional-us-central1",
+          "display_name": "spanner-instance",
+          "id": "{{.Provider.project}}/spanner-instance",
+          "labels": {
+            "label1": "value1",
+            "label2": "value2",
+            "label3": "value3"
+          },
+          "name": "spanner-instance",
+          "num_nodes": 1,
+          "state": "READY",
+          "timeouts": null
+        },
+        "after_unknown": {}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The PR introduces Spanner Instance objects consistent with the Public API representation of Spanner Instances auto-generated by Magic Modules. This is not exactly compatible with the existing CAI export of the same resource.

Validator OPA Policies should be compatible with both representation of the resource, if they need to be shared across monitoring and enforcement.