### PR TITLE
[Feedback request] Add ability to know if a field has changed.

### DIFF
--- a/tfplan/plan.go
+++ b/tfplan/plan.go
@@ -24,6 +24,8 @@ import (
 // Resource is the terraform representation of a resource.
 type Resource struct {
 	Path Fullpath
+	// Changes lists the fileds that have changed.
+	Changes []string
 	*fieldGetter
 }
 


### PR DESCRIPTION
This PR is not intended for merging as it is hacked together code.  

I'm requesting feedback on the approach I took for surfacing change information in a `google.Asset`.  I suspect my approach is incorrect  and could use some guidance as to what is correct.

Why:
* Working on a tool integration that only needs resources with a change
  in a particular field.

This change addresses the need by:
* Adds the needed fields so plan parsing will include the changes.
* Adds a function to parse the plan and determine which fields changed
  in which resourced.
* Augment the converter to keep the list of changed fields.
* Add a `HasChange` function to an `Asset` that checks if the provided
  string is in the list of changed fields.