### PR TITLE
Fixed warning related to specifying provider version inside provider configuration block

### DIFF
--- a/testdata/templates/bucket.tf
+++ b/testdata/templates/bucket.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/bucket_iam.tf
+++ b/testdata/templates/bucket_iam.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/disk.tf
+++ b/testdata/templates/disk.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_bigquery_dataset.tf
+++ b/testdata/templates/example_bigquery_dataset.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_compute_disk.tf
+++ b/testdata/templates/example_compute_disk.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_compute_firewall.tf
+++ b/testdata/templates/example_compute_firewall.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_compute_instance.tf
+++ b/testdata/templates/example_compute_instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_container_cluster.tf
+++ b/testdata/templates/example_container_cluster.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_organization_iam_binding.tf
+++ b/testdata/templates/example_organization_iam_binding.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_organization_iam_member.tf
+++ b/testdata/templates/example_organization_iam_member.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_organization_iam_policy.tf
+++ b/testdata/templates/example_organization_iam_policy.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project.tf
+++ b/testdata/templates/example_project.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_iam.tf
+++ b/testdata/templates/example_project_iam.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_iam_binding.tf
+++ b/testdata/templates/example_project_iam_binding.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_iam_member.tf
+++ b/testdata/templates/example_project_iam_member.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_iam_policy.tf
+++ b/testdata/templates/example_project_iam_policy.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_in_folder.tf
+++ b/testdata/templates/example_project_in_folder.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_in_org.tf
+++ b/testdata/templates/example_project_in_org.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_project_organization_policy.tf
+++ b/testdata/templates/example_project_organization_policy.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_sql_database_instance.tf
+++ b/testdata/templates/example_sql_database_instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/example_storage_bucket.tf
+++ b/testdata/templates/example_storage_bucket.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/firewall.tf
+++ b/testdata/templates/firewall.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_compute_firewall.tf
+++ b/testdata/templates/full_compute_firewall.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_compute_instance.tf
+++ b/testdata/templates/full_compute_instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_container_cluster.tf
+++ b/testdata/templates/full_container_cluster.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_container_node_pool.tf
+++ b/testdata/templates/full_container_node_pool.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_spanner_instance.tf
+++ b/testdata/templates/full_spanner_instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_sql_database_instance.tf
+++ b/testdata/templates/full_sql_database_instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/full_storage_bucket.tf
+++ b/testdata/templates/full_storage_bucket.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/instance.tf
+++ b/testdata/templates/instance.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 

--- a/testdata/templates/sql.tf
+++ b/testdata/templates/sql.tf
@@ -14,8 +14,16 @@
  * limitations under the License.
  */
 
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
 provider "google" {
-  version     = "~> {{.Provider.version}}"
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 


### PR DESCRIPTION
On master, many integration tests show the following warning:

```
Warning: Version constraints inside provider configuration blocks are deprecated
        
  on example_compute_disk.tf line 18, in provider "google":
  18:   version     = "~> 3.0.0"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.
```

This PR fixes that warning by updating all relevant files to use a `required_providers` block instead.