### PR TITLE
Corrected remaining integration test warnings

### DIFF
--- a/testdata/templates/example_compute_firewall.tf
+++ b/testdata/templates/example_compute_firewall.tf
@@ -29,7 +29,7 @@ provider "google" {
 
 resource "google_compute_firewall" "default" {
   name    = "test-firewall"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
   allow {
     protocol = "icmp"

--- a/testdata/templates/example_container_cluster.tf
+++ b/testdata/templates/example_container_cluster.tf
@@ -50,7 +50,7 @@ resource "google_container_cluster" "primary" {
 resource "google_container_node_pool" "primary_preemptible_nodes" {
   name       = "my-node-pool"
   location   = "us-central1"
-  cluster    = "${google_container_cluster.primary.name}"
+  cluster    = google_container_cluster.primary.name
   node_count = 1
 
   node_config {

--- a/testdata/templates/example_organization_iam_policy.tf
+++ b/testdata/templates/example_organization_iam_policy.tf
@@ -29,7 +29,7 @@ provider "google" {
 
 resource "google_organization_iam_policy" "policy" {
   org_id = "123456789"
-  policy_data = "${data.google_iam_policy.admin.policy_data}"
+  policy_data = data.google_iam_policy.admin.policy_data
 }
 
 data "google_iam_policy" "admin" {

--- a/testdata/templates/example_project.tf
+++ b/testdata/templates/example_project.tf
@@ -30,7 +30,7 @@ provider "google" {
 resource "google_project" "my_project-in-a-folder" {
   name = "My Project"
   project_id = "{{.Provider.project}}"
-  folder_id  = "${google_folder.department1.name}"
+  folder_id  = google_folder.department1.name
 
   billing_account = "{{.Project.BillingAccountName}}"
 

--- a/testdata/templates/example_project_iam_policy.tf
+++ b/testdata/templates/example_project_iam_policy.tf
@@ -29,7 +29,7 @@ provider "google" {
 
 resource "google_project_iam_policy" "project" {
   project     = "{{.Provider.project}}"
-  policy_data = "${data.google_iam_policy.admin.policy_data}"
+  policy_data = data.google_iam_policy.admin.policy_data
 }
 
 data "google_iam_policy" "admin" {

--- a/testdata/templates/full_compute_firewall.tf
+++ b/testdata/templates/full_compute_firewall.tf
@@ -29,7 +29,7 @@ provider "google" {
 
 resource "google_compute_firewall" "full_list_default_1" {
   name    = "test-firewall1"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
   allow {
     protocol = "icmp"

--- a/testdata/templates/full_compute_firewall.tf
+++ b/testdata/templates/full_compute_firewall.tf
@@ -50,7 +50,7 @@ resource "google_compute_firewall" "full_list_default_1" {
 
 resource "google_compute_firewall" "full_list_default_2" {
   name    = "test-firewall2"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
   deny {
     protocol = "icmp"
@@ -66,7 +66,7 @@ resource "google_compute_firewall" "full_list_default_2" {
 
 resource "google_compute_firewall" "full_list_default_3" {
   name    = "test-firewall3"
-  network = "${google_compute_network.default.name}"
+  network = google_compute_network.default.name
 
   deny {
     protocol = "icmp"

--- a/testdata/templates/full_sql_database_instance.tf
+++ b/testdata/templates/full_sql_database_instance.tf
@@ -33,7 +33,7 @@ resource "google_sql_database_instance" "master" {
   region           = "us-central1"
 
   depends_on = [
-    "google_service_networking_connection.private_vpc_connection"
+    google_service_networking_connection.private_vpc_connection
   ]
 
   master_instance_name = "test-master_instance_name"
@@ -86,7 +86,7 @@ resource "google_sql_database_instance" "master" {
         expiration_time = "test-expiration_time"
       }
       ipv4_enabled    = true
-      private_network = "${google_compute_network.private_network.self_link}"
+      private_network = google_compute_network.private_network.self_link
       require_ssl     = true
     }
     location_preference {

--- a/testdata/templates/full_sql_database_instance.tf
+++ b/testdata/templates/full_sql_database_instance.tf
@@ -117,11 +117,11 @@ resource "google_compute_global_address" "private_ip_address" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = "${google_compute_network.private_network.self_link}"
+  network       = google_compute_network.private_network.self_link
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  network                 = "${google_compute_network.private_network.self_link}"
+  network                 = google_compute_network.private_network.self_link
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = ["${google_compute_global_address.private_ip_address.name}"]
+  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
 }


### PR DESCRIPTION
In TF 0.11, quotes and interpolation were required in these cases; however, that is now deprecated.

The integration tests are still failing; this PR only resolves the warnings.