### PR TITLE
Fixed integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ run-docker:
 	docker run -it -v `pwd`:/terraform-validator -v ${GOOGLE_APPLICATION_CREDENTIALS}:/terraform-validator/credentials.json --entrypoint=/bin/bash --env TEST_PROJECT=${PROJECT_ID} --env TEST_CREDENTIALS=./credentials.json terraform-validator;
 
 test-integration:
+	go version
+	terraform --version
 	go test -v -run=CLI ./test
 
 build-docker:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201215184432-2a185a916cff
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083
 	github.com/forseti-security/config-validator v0.0.0-20200812033229-7388761cc9ca
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201214181215
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201214181215-ffdc48f9ffd3/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201215184432-2a185a916cff h1:Smbajo/A03R0nb/DGTeYB4RdzDoLyTOxREwPNhH6CmE=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201215184432-2a185a916cff/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083 h1:uS+/H+Edy+L/TdztwQL8L/kdR+znfjz1v8zC4zpV4q4=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -20,7 +20,7 @@ const (
 	defaultOrganization    = "12345"
 	defaultFolder          = "67890"
 	defaultProject         = "foobar"
-	defaultProviderVersion = "3.0.0"
+	defaultProviderVersion = "3.51.0"
 )
 
 var (

--- a/testdata/templates/bucket.json
+++ b/testdata/templates/bucket.json
@@ -9,7 +9,6 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-{{if eq .TFVersion "0.12"}}
         "billing": {},
         "lifecycle": {},
         "iamConfiguration": {
@@ -17,12 +16,6 @@
             "enabled": false
           }
         },
-{{else}}
-        "lifecycle": {
-          "rule": [
-          ]
-        },
-{{end}}
         "location": "EU",
         "name": "test-bucket",
         "project": "{{.Provider.project}}",

--- a/testdata/templates/disk.json
+++ b/testdata/templates/disk.json
@@ -9,19 +9,12 @@
       "discovery_name": "Disk",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "diskEncryptionKey": null,
         "labels": {
           "disk-label-key-a": "disk-label-val-a"
         },
         "name": "my-disk",
         "sourceImage": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
-        "sourceImageEncryptionKey": null,
-        "sourceSnapshotEncryptionKey": null,
-{{if eq .TFVersion "0.12"}}
         "type": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
-{{else}}
-        "type": "https://www.googleapis.com/compute/v1/projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
-{{end}}
         "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
       }
     }

--- a/testdata/templates/example_bigquery_dataset.json
+++ b/testdata/templates/example_bigquery_dataset.json
@@ -16,7 +16,6 @@
           "env": "dev"
         },
         "location": "EU",
-        "defaultEncryptionConfiguration": null,
         "defaultTableExpirationMs": 3.6e+06
       }
     }

--- a/testdata/templates/example_compute_disk.json
+++ b/testdata/templates/example_compute_disk.json
@@ -9,15 +9,12 @@
       "discovery_name": "Disk",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "diskEncryptionKey": null,
         "labels": {
           "environment": "dev"
         },
         "name": "test-disk",
         "physicalBlockSizeBytes": 4096,
         "sourceImage": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
-        "sourceImageEncryptionKey": null,
-        "sourceSnapshotEncryptionKey": null,
         "type": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
         "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
       }

--- a/testdata/templates/example_compute_instance.json
+++ b/testdata/templates/example_compute_instance.json
@@ -13,7 +13,7 @@
         "displayDevice": {
           "enableDisplay": false
         },
-        "shieldedVmConfig": {
+        "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": false,
           "enableSecureBoot": false,
           "enableVtpm": false
@@ -24,7 +24,7 @@
             "autoDelete": true,
             "boot": true,
             "initializeParams": {
-              "sourceImage": "projects/debian-cloud/global/images/debian-9"
+              "sourceImage": "projects/debian-cloud/global/images/family/debian-9"
             },
             "mode": "READ_WRITE"
           },
@@ -64,9 +64,7 @@
           {
             "email": "default",
             "scopes": [
-              "https://www.googleapis.com/auth/devstorage.read_only",
-              "https://www.googleapis.com/auth/userinfo.email",
-              "https://www.googleapis.com/auth/compute.readonly"
+              "https://www.googleapis.com/auth/cloud-platform"
             ]
           }
         ],

--- a/testdata/templates/example_compute_instance.tf
+++ b/testdata/templates/example_compute_instance.tf
@@ -27,6 +27,11 @@ provider "google" {
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
 resource "google_compute_instance" "default" {
   name         = "test"
   machine_type = "n1-standard-1"
@@ -36,7 +41,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "projects/debian-cloud/global/images/debian-9"
+      image = "debian-cloud/debian-9"
     }
   }
 
@@ -64,6 +69,7 @@ resource "google_compute_instance" "default" {
   # metadata_startup_script = "echo hi > /test.txt"
 
   service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+    email  = google_service_account.default.email
+    scopes = ["cloud-platform"]
   }
 }

--- a/testdata/templates/example_compute_instance.tfplan.json
+++ b/testdata/templates/example_compute_instance.tfplan.json
@@ -1,6 +1,6 @@
 {
   "format_version": "0.1",
-  "terraform_version": "0.12.20",
+  "terraform_version": "0.14.2",
   "planned_values": {
     "root_module": {
       "resources": [
@@ -9,7 +9,7 @@
           "mode": "managed",
           "type": "google_compute_instance",
           "name": "default",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 6,
           "values": {
             "allow_stopping_for_update": null,
@@ -20,7 +20,7 @@
                 "disk_encryption_key_raw": null,
                 "initialize_params": [
                   {
-                    "image": "projects/debian-cloud/global/images/debian-9"
+                    "image": "debian-cloud/debian-9"
                   }
                 ],
                 "mode": "READ_WRITE"
@@ -29,6 +29,7 @@
             "can_ip_forward": false,
             "deletion_protection": false,
             "description": null,
+            "desired_status": null,
             "enable_display": null,
             "hostname": null,
             "labels": null,
@@ -49,6 +50,7 @@
                 "network": "default"
               }
             ],
+            "resource_policies": null,
             "scratch_disk": [
               {
                 "interface": "SCSI"
@@ -57,9 +59,7 @@
             "service_account": [
               {
                 "scopes": [
-                  "https://www.googleapis.com/auth/compute.readonly",
-                  "https://www.googleapis.com/auth/devstorage.read_only",
-                  "https://www.googleapis.com/auth/userinfo.email"
+                  "https://www.googleapis.com/auth/cloud-platform"
                 ]
               }
             ],
@@ -71,6 +71,20 @@
             "timeouts": null,
             "zone": "us-central1-a"
           }
+        },
+        {
+          "address": "google_service_account.default",
+          "mode": "managed",
+          "type": "google_service_account",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "account_id": "service-account-id",
+            "description": null,
+            "display_name": "Service Account",
+            "timeouts": null
+          }
         }
       ]
     }
@@ -81,7 +95,7 @@
       "mode": "managed",
       "type": "google_compute_instance",
       "name": "default",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -96,7 +110,7 @@
               "disk_encryption_key_raw": null,
               "initialize_params": [
                 {
-                  "image": "projects/debian-cloud/global/images/debian-9"
+                  "image": "debian-cloud/debian-9"
                 }
               ],
               "mode": "READ_WRITE"
@@ -105,6 +119,7 @@
           "can_ip_forward": false,
           "deletion_protection": false,
           "description": null,
+          "desired_status": null,
           "enable_display": null,
           "hostname": null,
           "labels": null,
@@ -125,6 +140,7 @@
               "network": "default"
             }
           ],
+          "resource_policies": null,
           "scratch_disk": [
             {
               "interface": "SCSI"
@@ -133,9 +149,7 @@
           "service_account": [
             {
               "scopes": [
-                "https://www.googleapis.com/auth/compute.readonly",
-                "https://www.googleapis.com/auth/devstorage.read_only",
-                "https://www.googleapis.com/auth/userinfo.email"
+                "https://www.googleapis.com/auth/cloud-platform"
               ]
             }
           ],
@@ -165,6 +179,7 @@
             }
           ],
           "cpu_platform": true,
+          "current_status": true,
           "guest_accelerator": true,
           "id": true,
           "instance_id": true,
@@ -197,8 +212,6 @@
             {
               "email": true,
               "scopes": [
-                false,
-                false,
                 false
               ]
             }
@@ -211,17 +224,38 @@
           "tags_fingerprint": true
         }
       }
+    },
+    {
+      "address": "google_service_account.default",
+      "mode": "managed",
+      "type": "google_service_account",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "account_id": "service-account-id",
+          "description": null,
+          "display_name": "Service Account",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "email": true,
+          "id": true,
+          "name": true,
+          "project": true,
+          "unique_id": true
+        }
+      }
     }
   ],
   "configuration": {
     "provider_config": {
       "google": {
-        "name": "google",
-        "expressions": {
-          "project": {
-            "constant_value": "{{.Provider.project}}"
-          }
-        }
+        "name": "google"
       }
     },
     "root_module": {
@@ -238,7 +272,7 @@
                 "initialize_params": [
                   {
                     "image": {
-                      "constant_value": "projects/debian-cloud/global/images/debian-9"
+                      "constant_value": "debian-cloud/debian-9"
                     }
                   }
                 ]
@@ -274,11 +308,14 @@
             ],
             "service_account": [
               {
+                "email": {
+                  "references": [
+                    "google_service_account.default"
+                  ]
+                },
                 "scopes": {
                   "constant_value": [
-                    "userinfo-email",
-                    "compute-ro",
-                    "storage-ro"
+                    "cloud-platform"
                   ]
                 }
               }
@@ -294,6 +331,22 @@
             }
           },
           "schema_version": 6
+        },
+        {
+          "address": "google_service_account.default",
+          "mode": "managed",
+          "type": "google_service_account",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "account_id": {
+              "constant_value": "service-account-id"
+            },
+            "display_name": {
+              "constant_value": "Service Account"
+            }
+          },
+          "schema_version": 0
         }
       ]
     }

--- a/testdata/templates/example_container_cluster.json
+++ b/testdata/templates/example_container_cluster.json
@@ -9,22 +9,10 @@
       "discovery_name": "Cluster",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "addonsConfig": null,
-        "binaryAuthorization": null,
-        "defaultMaxPodsConstraint": null,
         "initialNodeCount": 1,
-        "ipAllocationPolicy": null,
-        "legacyAbac": null,
         "location": "us-central1",
-        "loggingService": "logging.googleapis.com/kubernetes",
-        "masterAuthorizedNetworksConfig": null,
-        "monitoringService": "monitoring.googleapis.com/kubernetes",
         "name": "my-gke-cluster",
-        "network": "projects/{{.Provider.project}}/global/networks/default",
-        "networkPolicy": null,
-        "nodeConfig": null,
-        "podSecurityPolicyConfig": null,
-        "privateClusterConfig": null
+        "network": "projects/{{.Provider.project}}/global/networks/default"
       }
     }
   },
@@ -38,7 +26,6 @@
       "discovery_name": "NodePool",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "autoscaling": null,
         "cluster": "projects/{{.Provider.project}}/global/clusters/my-gke-cluster",
         "config": {
           "machineType": "n1-standard-1",
@@ -46,14 +33,11 @@
             "disable-legacy-endpoints": "true"
           },
           "oauthScopes": [
-            "https://www.googleapis.com/auth/monitoring",
-            "https://www.googleapis.com/auth/logging.write"
+            "https://www.googleapis.com/auth/cloud-platform"
           ],
           "preemptible": true
         },
         "location": "us-central1",
-        "management": null,
-        "maxPodsConstraint": null,
         "name": "my-node-pool"
       }
     }

--- a/testdata/templates/example_container_cluster.tf
+++ b/testdata/templates/example_container_cluster.tf
@@ -27,6 +27,11 @@ provider "google" {
   {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
 }
 
+resource "google_service_account" "default" {
+  account_id   = "service-account-id"
+  display_name = "Service Account"
+}
+
 resource "google_container_cluster" "primary" {
   name     = "my-gke-cluster"
   location = "us-central1"
@@ -36,15 +41,6 @@ resource "google_container_cluster" "primary" {
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count = 1
-
-  master_auth {
-    username = ""
-    password = ""
-
-    client_certificate_config {
-      issue_client_certificate = false
-    }
-  }
 }
 
 resource "google_container_node_pool" "primary_preemptible_nodes" {
@@ -61,9 +57,9 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
       disable-legacy-endpoints = "true"
     }
 
+    service_account = google_service_account.default.email
     oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/cloud-platform",
     ]
   }
 }

--- a/testdata/templates/example_container_cluster.tfplan.json
+++ b/testdata/templates/example_container_cluster.tfplan.json
@@ -1,6 +1,6 @@
 {
   "format_version": "0.1",
-  "terraform_version": "0.12.20",
+  "terraform_version": "0.14.2",
   "planned_values": {
     "root_module": {
       "resources": [
@@ -9,39 +9,32 @@
           "mode": "managed",
           "type": "google_container_cluster",
           "name": "primary",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 1,
           "values": {
             "description": null,
             "enable_binary_authorization": false,
+            "enable_intranode_visibility": null,
             "enable_kubernetes_alpha": false,
             "enable_legacy_abac": false,
+            "enable_shielded_nodes": false,
+            "enable_tpu": null,
             "initial_node_count": 1,
             "ip_allocation_policy": [],
             "location": "us-central1",
-            "logging_service": "logging.googleapis.com/kubernetes",
             "maintenance_policy": [],
-            "master_auth": [
-              {
-                "client_certificate_config": [
-                  {
-                    "issue_client_certificate": false
-                  }
-                ],
-                "password": "",
-                "username": ""
-              }
-            ],
             "master_authorized_networks_config": [],
             "min_master_version": null,
-            "monitoring_service": "monitoring.googleapis.com/kubernetes",
             "name": "my-gke-cluster",
             "network": "default",
+            "pod_security_policy_config": [],
             "private_cluster_config": [],
             "remove_default_node_pool": true,
             "resource_labels": null,
+            "resource_usage_export_config": [],
             "timeouts": null,
-            "vertical_pod_autoscaling": []
+            "vertical_pod_autoscaling": [],
+            "workload_identity_config": []
           }
         },
         {
@@ -49,7 +42,7 @@
           "mode": "managed",
           "type": "google_container_node_pool",
           "name": "primary_preemptible_nodes",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 1,
           "values": {
             "autoscaling": [],
@@ -64,14 +57,27 @@
                 },
                 "min_cpu_platform": null,
                 "oauth_scopes": [
-                  "https://www.googleapis.com/auth/logging.write",
-                  "https://www.googleapis.com/auth/monitoring"
+                  "https://www.googleapis.com/auth/cloud-platform"
                 ],
                 "preemptible": true,
                 "tags": null
               }
             ],
             "node_count": 1,
+            "timeouts": null
+          }
+        },
+        {
+          "address": "google_service_account.default",
+          "mode": "managed",
+          "type": "google_service_account",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "account_id": "service-account-id",
+            "description": null,
+            "display_name": "Service Account",
             "timeouts": null
           }
         }
@@ -84,7 +90,7 @@
       "mode": "managed",
       "type": "google_container_cluster",
       "name": "primary",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -93,76 +99,62 @@
         "after": {
           "description": null,
           "enable_binary_authorization": false,
+          "enable_intranode_visibility": null,
           "enable_kubernetes_alpha": false,
           "enable_legacy_abac": false,
+          "enable_shielded_nodes": false,
+          "enable_tpu": null,
           "initial_node_count": 1,
           "ip_allocation_policy": [],
           "location": "us-central1",
-          "logging_service": "logging.googleapis.com/kubernetes",
           "maintenance_policy": [],
-          "master_auth": [
-            {
-              "client_certificate_config": [
-                {
-                  "issue_client_certificate": false
-                }
-              ],
-              "password": "",
-              "username": ""
-            }
-          ],
           "master_authorized_networks_config": [],
           "min_master_version": null,
-          "monitoring_service": "monitoring.googleapis.com/kubernetes",
           "name": "my-gke-cluster",
           "network": "default",
+          "pod_security_policy_config": [],
           "private_cluster_config": [],
           "remove_default_node_pool": true,
           "resource_labels": null,
+          "resource_usage_export_config": [],
           "timeouts": null,
-          "vertical_pod_autoscaling": []
+          "vertical_pod_autoscaling": [],
+          "workload_identity_config": []
         },
         "after_unknown": {
-          "additional_zones": true,
           "addons_config": true,
           "authenticator_groups_config": true,
           "cluster_autoscaling": true,
           "cluster_ipv4_cidr": true,
+          "database_encryption": true,
           "default_max_pods_per_node": true,
-          "enable_intranode_visibility": true,
-          "enable_tpu": true,
           "endpoint": true,
           "id": true,
           "instance_group_urls": true,
           "ip_allocation_policy": [],
           "label_fingerprint": true,
+          "logging_service": true,
           "maintenance_policy": [],
-          "master_auth": [
-            {
-              "client_certificate": true,
-              "client_certificate_config": [
-                {}
-              ],
-              "client_key": true,
-              "cluster_ca_certificate": true
-            }
-          ],
+          "master_auth": true,
           "master_authorized_networks_config": [],
           "master_version": true,
+          "monitoring_service": true,
           "network_policy": true,
           "node_config": true,
           "node_locations": true,
           "node_pool": true,
           "node_version": true,
           "operation": true,
-          "pod_security_policy_config": true,
+          "pod_security_policy_config": [],
           "private_cluster_config": [],
           "project": true,
-          "region": true,
+          "release_channel": true,
+          "resource_usage_export_config": [],
+          "self_link": true,
           "services_ipv4_cidr": true,
           "subnetwork": true,
           "vertical_pod_autoscaling": [],
-          "zone": true
+          "workload_identity_config": []
         }
       }
     },
@@ -171,7 +163,7 @@
       "mode": "managed",
       "type": "google_container_node_pool",
       "name": "primary_preemptible_nodes",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -190,8 +182,7 @@
               },
               "min_cpu_platform": null,
               "oauth_scopes": [
-                "https://www.googleapis.com/auth/logging.write",
-                "https://www.googleapis.com/auth/monitoring"
+                "https://www.googleapis.com/auth/cloud-platform"
               ],
               "preemptible": true,
               "tags": null
@@ -218,20 +209,44 @@
               "local_ssd_count": true,
               "metadata": {},
               "oauth_scopes": [
-                false,
                 false
               ],
-              "sandbox_config": true,
               "service_account": true,
               "shielded_instance_config": true,
               "taint": true,
               "workload_metadata_config": true
             }
           ],
+          "node_locations": true,
           "project": true,
-          "region": true,
-          "version": true,
-          "zone": true
+          "upgrade_settings": true,
+          "version": true
+        }
+      }
+    },
+    {
+      "address": "google_service_account.default",
+      "mode": "managed",
+      "type": "google_service_account",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "account_id": "service-account-id",
+          "description": null,
+          "display_name": "Service Account",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "email": true,
+          "id": true,
+          "name": true,
+          "project": true,
+          "unique_id": true
         }
       }
     }
@@ -252,23 +267,6 @@
             "location": {
               "constant_value": "us-central1"
             },
-            "master_auth": [
-              {
-                "client_certificate_config": [
-                  {
-                    "issue_client_certificate": {
-                      "constant_value": false
-                    }
-                  }
-                ],
-                "password": {
-                  "constant_value": ""
-                },
-                "username": {
-                  "constant_value": ""
-                }
-              }
-            ],
             "name": {
               "constant_value": "my-gke-cluster"
             },
@@ -308,12 +306,16 @@
                 },
                 "oauth_scopes": {
                   "constant_value": [
-                    "https://www.googleapis.com/auth/logging.write",
-                    "https://www.googleapis.com/auth/monitoring"
+                    "https://www.googleapis.com/auth/cloud-platform"
                   ]
                 },
                 "preemptible": {
                   "constant_value": true
+                },
+                "service_account": {
+                  "references": [
+                    "google_service_account.default"
+                  ]
                 }
               }
             ],
@@ -322,6 +324,22 @@
             }
           },
           "schema_version": 1
+        },
+        {
+          "address": "google_service_account.default",
+          "mode": "managed",
+          "type": "google_service_account",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "account_id": {
+              "constant_value": "service-account-id"
+            },
+            "display_name": {
+              "constant_value": "Service Account"
+            }
+          },
+          "schema_version": 0
         }
       ]
     }

--- a/testdata/templates/example_sql_database_instance.json
+++ b/testdata/templates/example_sql_database_instance.json
@@ -15,7 +15,6 @@
         "region": "us-central1",
         "settings": {
           "pricingPlan": "PER_USE",
-          "replicationType": "SYNCHRONOUS",
           "storageAutoResize": true,
           "tier": "db-f1-micro"
         }

--- a/testdata/templates/firewall.json
+++ b/testdata/templates/firewall.json
@@ -22,7 +22,7 @@
                 ]
             }
         ],
-        {{if eq .TFVersion "0.12"}}"disabled": false,{{end}}
+        "disabled": false,
         "logConfig": {
           "enable": false
         },

--- a/testdata/templates/full_compute_instance.json
+++ b/testdata/templates/full_compute_instance.json
@@ -13,7 +13,7 @@
         "displayDevice": {
           "enableDisplay": false
         },
-        "shieldedVmConfig": {
+        "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true,
           "enableSecureBoot": true,
           "enableVtpm": true
@@ -129,9 +129,7 @@
           {
             "email": "test-email",
             "scopes": [
-              "https://www.googleapis.com/auth/devstorage.read_only",
-              "https://www.googleapis.com/auth/userinfo.email",
-              "https://www.googleapis.com/auth/compute.readonly"
+              "https://www.googleapis.com/auth/cloud-platform"
             ]
           }
         ],
@@ -158,7 +156,7 @@
         "displayDevice": {
           "enableDisplay": false
         },
-        "shieldedVmConfig": {
+        "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": false,
           "enableSecureBoot": false,
           "enableVtpm": false

--- a/testdata/templates/full_compute_instance.tf
+++ b/testdata/templates/full_compute_instance.tf
@@ -123,7 +123,7 @@ resource "google_compute_instance" "full_list_default_1" {
   }
   service_account {
     email  = "test-email"
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+    scopes = ["cloud-platform"]
   }
   shielded_instance_config {
     enable_secure_boot          = true

--- a/testdata/templates/full_compute_instance.tfplan.json
+++ b/testdata/templates/full_compute_instance.tfplan.json
@@ -128,9 +128,7 @@
               {
                 "email": "test-email",
                 "scopes": [
-                  "https://www.googleapis.com/auth/compute.readonly",
-                  "https://www.googleapis.com/auth/devstorage.read_only",
-                  "https://www.googleapis.com/auth/userinfo.email"
+                  "https://www.googleapis.com/auth/cloud-platform"
                 ]
               }
             ],

--- a/testdata/templates/full_container_cluster.json
+++ b/testdata/templates/full_container_cluster.json
@@ -20,7 +20,6 @@
             "disabled": true
           }
         },
-        "binaryAuthorization": null,
         "defaultMaxPodsConstraint": {
           "maxPodsPerNode": 42
         },
@@ -100,7 +99,6 @@
             "test-tags"
           ]
         },
-        "podSecurityPolicyConfig": null,
         "privateClusterConfig": {
           "enablePrivateEndpoint": true,
           "enablePrivateNodes": true,

--- a/testdata/templates/instance.json
+++ b/testdata/templates/instance.json
@@ -13,7 +13,7 @@
         "displayDevice": {
           "enableDisplay": false
         },
-        "shieldedVmConfig": {
+        "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": false,
           "enableSecureBoot": false,
           "enableVtpm": false
@@ -31,21 +31,13 @@
           {
             "autoDelete": true,
             "initializeParams": {
-      {{if eq .TFVersion "0.12"}}
               "diskType": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/local-ssd"
-      {{else}}
-              "diskType": "https://www.googleapis.com/compute/v1/projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/local-ssd"
-      {{end}}
             },
             "interface": "SCSI",
             "type": "SCRATCH"
           }
         ],
-      {{if eq .TFVersion "0.12"}}
         "machineType": "projects/{{.Provider.project}}/zones/us-central1-a/machineTypes/n1-standard-1",
-      {{else}}
-        "machineType": "https://www.googleapis.com/compute/v1/projects/{{.Provider.project}}/zones/us-central1-a/machineTypes/n1-standard-1",
-      {{end}}
         "metadata": {
           "items": [
             {
@@ -72,9 +64,7 @@
           {
             "email": "default",
             "scopes": [
-              "https://www.googleapis.com/auth/devstorage.read_only",
-              "https://www.googleapis.com/auth/userinfo.email",
-              "https://www.googleapis.com/auth/compute.readonly"
+              "https://www.googleapis.com/auth/cloud-platform"
             ]
           }
         ],

--- a/testdata/templates/instance.tf
+++ b/testdata/templates/instance.tf
@@ -57,6 +57,6 @@ resource "google_compute_instance" "my-test-instance" {
   metadata_startup_script = "echo hi > /test.txt"
 
   service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+    scopes = ["cloud-platform"]
   }
 }

--- a/testdata/templates/sql.json
+++ b/testdata/templates/sql.json
@@ -15,7 +15,6 @@
         "region": "us-central1",
         "settings": {
           "pricingPlan": "PER_USE",
-          "replicationType": "SYNCHRONOUS",
           "storageAutoResize": true,
           "tier": "db-f1-micro"
         }


### PR DESCRIPTION
This PR fixes the integration tests. It is related to #158.

It seems like there are a few systemic changes to the terraform-google-conversion repo and a few that are specific to certain resources. For example, the replicationType field on SQL resources is deprecated.

I tried to update things where it seemed like it might make sense; however, for the most part I assumed that we want tests that validate that the current behavior won't break going forward - i.e. that it is currently working correctly. If that's not the case for any of these, I suggest we fix it in separate PRs.

In addition to the fixes, I also made the integration tests output what versions of go and terraform they use.