### PR TITLE
update terraform-google-conversion version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b
 	github.com/forseti-security/config-validator v0.0.0-20200812033229-7388761cc9ca
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
@@ -11,6 +12,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/api v0.35.0
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
 )

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201215184432
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201215184432-2a185a916cff/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083 h1:uS+/H+Edy+L/TdztwQL8L/kdR+znfjz1v8zC4zpV4q4=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b h1:9Xst9+aekPwyp1Tdt1G6fK9G3zbhUgFCjDM3cOJriLA=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/testdata/templates/bucket.json
+++ b/testdata/templates/bucket.json
@@ -12,7 +12,7 @@
         "billing": {},
         "lifecycle": {},
         "iamConfiguration": {
-          "bucketPolicyOnly": {
+          "uniformBucketLevelAccess": {
             "enabled": false
           }
         },

--- a/testdata/templates/example_storage_bucket.json
+++ b/testdata/templates/example_storage_bucket.json
@@ -11,7 +11,7 @@
       "data": {
         "billing": {},
         "iamConfiguration": {
-          "bucketPolicyOnly": {
+          "uniformBucketLevelAccess": {
             "enabled": false
           }
         },

--- a/testdata/templates/full_storage_bucket.json
+++ b/testdata/templates/full_storage_bucket.json
@@ -48,7 +48,7 @@
           "defaultKmsKeyName": "test-default_kms_key_name"
         },
         "iamConfiguration": {
-          "bucketPolicyOnly": {
+          "uniformBucketLevelAccess": {
             "enabled": true
           }
         },


### PR DESCRIPTION
Change in this PR:

-  Bump of the `terraform-google-conversion` library version to the newest one: `v0.0.0-20210105223515-0824b0da180b`
-  Fixes in the CLI tests to consider the replacement, in the storage bucket code, of the deprecated attribute `bucketPolicyOnly` with the  new attribute `uniformBucketLevelAccess` brought by the new version of the `terraform-google-conversion`