### PR TITLE
Merge project IAM policy bindings

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -145,6 +145,7 @@ func NewConverter(ctx context.Context, ancestryManager ancestrymanager.AncestryM
 		schema:          provider.Provider(),
 		mapperFuncs:     mappers(),
 		cfg:             cfg,
+		offline:         offline,
 		ancestryManager: ancestryManager,
 		assets:          make(map[string]Asset),
 	}, nil
@@ -160,6 +161,9 @@ type Converter struct {
 	mapperFuncs map[string][]mapper
 
 	cfg *converter.Config
+
+	// If true, the converter should not attempt to make real API connections.
+	offline bool
 
 	// ancestryManager provides a manager to find the ancestry information for a project.
 	ancestryManager ancestrymanager.AncestryManager
@@ -200,7 +204,7 @@ func (c *Converter) AddResource(r TerraformResource) error {
 		// The existence of a newIamUpdater function signals that this tf
 		// resource needs to be merged with existing remote IAM data to be useful.
 		// This will be run once, for the first IAM policy encountered.
-		if mapper.newIamUpdater != nil {
+		if mapper.newIamUpdater != nil && !c.offline {
 			if _, exists := c.assets[key]; !exists {
 				updater, _ := mapper.newIamUpdater(data, c.cfg)
 				iam_policy, _ := updater.GetResourceIamPolicy()

--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -27,12 +27,17 @@ type convertFunc func(d converter.TerraformResourceData, config *converter.Confi
 // google_project_iam_member -> google.cloud.resourcemanager/Project
 type mergeFunc func(existing, incoming converter.Asset) converter.Asset
 
+// This represents an iam updater func like you would get from terraform-google-conversion
+type newResourceIamUpdaterFunc func(d converter.TerraformResourceData, config *converter.Config) (converter.ResourceIamUpdater, error)
+
 // mapper pairs related conversion/merging functions.
 type mapper struct {
 	// convert must be defined.
 	convert convertFunc
 	// merge may be defined.
 	merge mergeFunc
+	// new_iam_updater may be defined
+	newIamUpdater newResourceIamUpdaterFunc
 }
 
 // mappers maps terraform resource types (i.e. `google_project`) into
@@ -81,14 +86,16 @@ func mappers() map[string][]mapper {
 		},
 		"google_organization_iam_binding": {
 			{
-				convert: converter.GetOrganizationIamBindingCaiObject,
-				merge:   converter.MergeOrganizationIamBinding,
+				convert:       converter.GetOrganizationIamBindingCaiObject,
+				merge:         converter.MergeOrganizationIamBinding,
+				newIamUpdater: converter.NewOrganizationIamUpdater,
 			},
 		},
 		"google_organization_iam_member": {
 			{
-				convert: converter.GetOrganizationIamMemberCaiObject,
-				merge:   converter.MergeOrganizationIamMember,
+				convert:       converter.GetOrganizationIamMemberCaiObject,
+				merge:         converter.MergeOrganizationIamMember,
+				newIamUpdater: converter.NewOrganizationIamUpdater,
 			},
 		},
 		"google_folder_iam_policy": {

--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -88,14 +88,12 @@ func mappers() map[string][]mapper {
 			{
 				convert:       converter.GetOrganizationIamBindingCaiObject,
 				merge:         converter.MergeOrganizationIamBinding,
-				newIamUpdater: converter.NewOrganizationIamUpdater,
 			},
 		},
 		"google_organization_iam_member": {
 			{
 				convert:       converter.GetOrganizationIamMemberCaiObject,
 				merge:         converter.MergeOrganizationIamMember,
-				newIamUpdater: converter.NewOrganizationIamUpdater,
 			},
 		},
 		"google_folder_iam_policy": {
@@ -126,12 +124,14 @@ func mappers() map[string][]mapper {
 			{
 				convert: converter.GetProjectIamBindingCaiObject,
 				merge:   converter.MergeProjectIamBinding,
+				newIamUpdater: converter.NewProjectIamUpdater,
 			},
 		},
 		"google_project_iam_member": {
 			{
 				convert: converter.GetProjectIamMemberCaiObject,
 				merge:   converter.MergeProjectIamMember,
+				newIamUpdater: converter.NewProjectIamUpdater,
 			},
 		},
 		"google_storage_bucket_iam_policy": {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf
 	github.com/forseti-security/config-validator v0.0.0-20200812033229-7388761cc9ca
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210122223058-b0ac0acd4d44
 	github.com/forseti-security/config-validator v0.0.0-20200812033229-7388761cc9ca
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20201217205113-a225f83a5083/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b h1:9Xst9+aekPwyp1Tdt1G6fK9G3zbhUgFCjDM3cOJriLA=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf h1:3e98QjnP9XwU5Fr66I9/e4HLC+QPWF+RhOYU9TIaxsU=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210105223515-0824b0da180b/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf h1:3e98QjnP9XwU5Fr66I9/e4HLC+QPWF+RhOYU9TIaxsU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210121213639-7e4e0af5bebf/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210122223058-b0ac0acd4d44 h1:3aXg2+9BwycdbVLq19ZQywZV2VKH93ECcRL/bePT55c=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210122223058-b0ac0acd4d44/go.mod h1:6DDmxUBVxmupfYML5IAf8V8HIHeloIQiYFbiMNJHyVU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
This PR sets up merging of project IAM policy bindings from GCP into the local bindings prior to validation. This means that validation and other functionality (like simulation) will be able to reference the full IAM policy, even if the user is using member or binding resources in their terraform.

You can test this manually by making a file locally like this:

```
resource "google_project" "my_project" {
  name       = "Whatever you want here"
  project_id = "<your test project ID>"
  org_id     = "whatever you want here"
}


resource "google_project_iam_binding" "project" {
  project = "<your test project ID>"
  role    = "roles/viewer"

  members = [
    "user:some-user-email",
  ]
}
```

Once you have this file in a directory, run:
```
cd path/to/terraform-validator
make build
cd path/to/test/dir
terraform plan --out=tfplan.tfplan 
terraform show -json tfplan.tfplan > tfplan.json
path/to/terraform-validator/bin/terraform-validator convert tfplan.json
```

Without these changes, the output will only contain the binding defined in terraform; with these changes, it will also contain your project's full iam policy.

I would like to have automated tests for this but am unsure how to go about implementing them. If you have any advice I would love to hear it!

Related to issue https://github.com/hashicorp/terraform-provider-google/issues/7797. Note: This PR only implements project IAM policy related functionality. Follow-up PRs will build on this for other IAM resources.