### PR TITLE
Switched to reading resource changes instead of planned resource values

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -181,8 +181,9 @@ func (c *Converter) Schemas() map[string]*schema.Resource {
 
 // AddResource converts a terraform resource and stores the converted asset.
 func (c *Converter) AddResource(rc *tfplan.ResourceChange) error {
-	// Compatibility shim: silently do nothing with deleted resources.
-	if len(rc.Change.Actions) == 1 && rc.Change.Actions[0] == "delete" {
+	// Compatibility shim: silently do nothing if this resource isn't
+	// being added or changed.
+	if !(rc.IsCreate() || rc.IsUpdate() || rc.IsDeleteCreate()) {
 		return nil
 	}
 

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -24,6 +24,7 @@ import (
 	provider "github.com/hashicorp/terraform-provider-google/v3/google"
 	"github.com/pkg/errors"
 
+	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
 	converter "github.com/GoogleCloudPlatform/terraform-google-conversion/google"
 	"github.com/GoogleCloudPlatform/terraform-validator/ancestrymanager"
 )
@@ -179,7 +180,30 @@ func (c *Converter) Schemas() map[string]*schema.Resource {
 }
 
 // AddResource converts a terraform resource and stores the converted asset.
-func (c *Converter) AddResource(r TerraformResource) error {
+func (c *Converter) AddResource(rc *tfplan.ResourceChange) error {
+	// Compatibility shim: silently do nothing with deleted resources.
+	if len(rc.Change.Actions) == 1 && rc.Change.Actions[0] == "delete" {
+		return nil
+	}
+
+	// Compatibility shim: silently skip unknown resources
+	resource, ok := c.schema.ResourcesMap[rc.Type]
+	if !ok {
+		return nil
+	}
+
+	// Compatibility shim: silently skip unsupported resources
+	if _, ok := c.mapperFuncs[rc.Type]; !ok {
+		return nil
+	}
+
+	rd := NewFakeResourceData(
+		rc.Type,
+		resource.Schema,
+		rc.Change.After,
+	)
+	r := &rd
+
 	for _, mapper := range c.mapperFuncs[r.Kind()] {
 		data := struct {
 			TerraformResource

--- a/test/read_planned_assets/tf12plan.allcoverage.json
+++ b/test/read_planned_assets/tf12plan.allcoverage.json
@@ -377,7 +377,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "description": null,
@@ -460,7 +460,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "allow": [
@@ -567,7 +567,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "allow_stopping_for_update": null,
@@ -791,7 +791,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "folder": "my-folder",
@@ -824,7 +824,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "folder": "my-folder",
@@ -850,7 +850,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "folder": "my-folder",
@@ -874,7 +874,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "members": [
@@ -907,7 +907,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "member": "user:jane@example.com",
@@ -933,7 +933,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "org_id": "123456789",
@@ -957,7 +957,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "auto_create_network": true,
@@ -1002,7 +1002,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "members": [
@@ -1035,7 +1035,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "member": "user:jane@example.com",
@@ -1061,7 +1061,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "authoritative": null,
@@ -1090,7 +1090,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "database_version": "POSTGRES_9_6",
@@ -1179,7 +1179,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "cors": [

--- a/test/read_planned_assets/tf12plan.json
+++ b/test/read_planned_assets/tf12plan.json
@@ -94,7 +94,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "allow": [
@@ -172,7 +172,7 @@
       "provider_name": "google",
       "change": {
         "actions": [
-          "no-op"
+          "create"
         ],
         "before": {
           "allow": [

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -39,16 +39,14 @@ func ReadPlannedAssets(ctx context.Context, path, project, ancestry string, offl
 		return nil, err
 	}
 
-	var resources []google.FakeResourceData
-
 	data, err := readTF12Data(path)
 	if err != nil {
 		return nil, err
 	}
 
-	resources, err = tfplan.ComposeTF12Resources(data, converter.Schemas())
+	resources, err := tfplan.ComposeTF12Resources(data, converter.Schemas())
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal from JSON and composing terraform plan")
+		return nil, errors.Wrap(err, "reading resource changes")
 	}
 
 	for _, r := range resources {

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -15,10 +15,7 @@ package tfplan
 
 import (
 	"encoding/json"
-	"log"
-	"strings"
 
-	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
 )
@@ -28,19 +25,13 @@ const maxChildModuleLevel = 10000
 // jsonPlan structure used to parse Terraform 12 plan exported in json format by 'terraform show -json ./binary_plan.tfplan' command.
 // https://www.terraform.io/docs/internals/json-format.html#plan-representation
 type jsonPlan struct {
-	PlannedValues struct {
-		RootModules struct {
-			Resources    []jsonResource `json:"resources"`
-			ChildModules []childModule  `json:"child_modules"`
-		} `json:"root_module"`
-	} `json:"planned_values"`
-	ResourceChanges []jsonResourceChange `json:"resource_changes"`
+	ResourceChanges []ResourceChange `json:"resource_changes"`
 }
 
-type jsonResourceChange struct {
+type ResourceChange struct {
 	Address      string `json:"address"`
 	Mode         string `json:"mode"`
-	Kind         string `json:"type"`
+	Type         string `json:"type"`
 	Name         string `json:"name"`
 	ProviderName string `json:"provider_name"`
 	Change       struct {
@@ -59,111 +50,27 @@ type jsonResourceChange struct {
 }
 
 // isCreate returns true if the action on the resource is ["create"].
-func (c *jsonResourceChange) isCreate() bool {
+func (c *ResourceChange) isCreate() bool {
 	return len(c.Change.Actions) == 1 && c.Change.Actions[0] == "create"
 }
 
-type childModule struct {
-	Address      string         `json:"address"`
-	Resources    []jsonResource `json:"resources"`
-	ChildModules []childModule  `json:"child_modules"`
+// compatibility shim until ResourceChange is expected by all callers.
+func (c *ResourceChange) Kind() string {
+	return c.Type
 }
 
-// jsonResource represent single Terraform resource definition.
-type jsonResource struct {
-	Module       string                 `json:"module"`
-	Name         string                 `json:"name"`
-	Address      string                 `json:"address"`
-	Mode         string                 `json:"mode"`
-	Kind         string                 `json:"type"`
-	ProviderName string                 `json:"provider_name"`
-	Values       map[string]interface{} `json:"values"`
+// ComposeTF12Resources is a thin wrapper around ReadResourceChanges as a compatibility shim.
+func ComposeTF12Resources(data []byte, schemas map[string]*schema.Resource) ([]ResourceChange, error) {
+	return ReadResourceChanges(data)
 }
 
-// ComposeTF12Resources inspects a plan and returns the planned resources that match the provided resource schema map.
-// ComposeTF12Resources works in a same way as tfplan.ComposeResources and returns array of tfplan.Resource
-func ComposeTF12Resources(data []byte, schemas map[string]*schema.Resource) ([]google.FakeResourceData, error) {
-	plan, err := readPlan(data)
-	if err != nil {
-		return nil, err
-	}
-	resources := readPlannedJSONResources(plan)
-	return jsonToResources(resources, schemas), nil
-}
-
-// jsonToResource converts the jsonResources to tfplan.Resource using the provided schemas.
-// Any resources not supported by the schemas are silently skipped.
-func jsonToResources(resources []jsonResource, schemas map[string]*schema.Resource) []google.FakeResourceData {
-	var instances []google.FakeResourceData
-	for _, r := range resources {
-		sch, ok := schemas[r.Kind]
-		if !ok {
-			// Unsupported in given provider schema.
-			continue
-		}
-
-		instances = append(instances, google.NewFakeResourceData(
-			r.Kind,
-			sch.Schema,
-			r.Values,
-		))
-	}
-	return instances
-}
-
-func jsonResourceFromChange(c jsonResourceChange) jsonResource {
-	return jsonResource{
-		Name:         c.Name,
-		Address:      c.Address,
-		Mode:         c.Mode,
-		Kind:         c.Kind,
-		ProviderName: c.ProviderName,
-		Values:       c.Change.Before,
-	}
-}
-
-// readPlan converts the raw bytes into a jsonPlan
-func readPlan(data []byte) (jsonPlan, error) {
+// ReadResourceChanges returns the list of resource changes from a json plan
+func ReadResourceChanges(data []byte) ([]ResourceChange, error) {
 	plan := jsonPlan{}
 	err := json.Unmarshal(data, &plan)
 	if err != nil {
-		return jsonPlan{}, errors.Wrap(err, "read resources")
+		return nil, errors.Wrap(err, "reading JSON plan")
 	}
-	return plan, nil
-}
 
-// readPlannedJSONResources reads a jsonPlan and returns an array of all
-// planned jsonResources.
-// This includes resources from both from root and child modules.
-func readPlannedJSONResources(plan jsonPlan) []jsonResource {
-	var result []jsonResource
-	for _, resource := range plan.PlannedValues.RootModules.Resources {
-		resource.Module = "root"
-		result = append(result, resource)
-	}
-	for _, module := range plan.PlannedValues.RootModules.ChildModules {
-		result = append(result, resourcesFromModule(&module, 0)...)
-	}
-	return result
-}
-
-func resourcesFromModule(module *childModule, level int) []jsonResource {
-	if level > maxChildModuleLevel {
-		log.Printf("The configuration has more than %d level of modules. Modules with a depth more than %d will be ignored.", maxChildModuleLevel, maxChildModuleLevel)
-		return nil
-	}
-	pcs := strings.SplitAfterN(module.Address, ".", 2)
-	if len(pcs) < 2 {
-		return nil
-	}
-	name := pcs[1]
-	var result []jsonResource
-	for _, resource := range module.Resources {
-		resource.Module = name
-		result = append(result, resource)
-	}
-	for _, c := range module.ChildModules {
-		result = append(result, resourcesFromModule(&c, level+1)...)
-	}
-	return result
+	return plan.ResourceChanges, nil
 }

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -20,8 +20,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const maxChildModuleLevel = 10000
-
 // jsonPlan structure used to parse Terraform 12 plan exported in json format by 'terraform show -json ./binary_plan.tfplan' command.
 // https://www.terraform.io/docs/internals/json-format.html#plan-representation
 type jsonPlan struct {

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -47,9 +47,16 @@ type ResourceChange struct {
 	} `json:"change"`
 }
 
-// isCreate returns true if the action on the resource is ["create"].
-func (c *ResourceChange) isCreate() bool {
+func (c *ResourceChange) IsCreate() bool {
 	return len(c.Change.Actions) == 1 && c.Change.Actions[0] == "create"
+}
+
+func (c *ResourceChange) IsUpdate() bool {
+	return len(c.Change.Actions) == 1 && c.Change.Actions[0] == "update"
+}
+
+func (c *ResourceChange) IsDeleteCreate() bool {
+	return len(c.Change.Actions) == 2 && c.Change.Actions[0] == "delete"
 }
 
 // compatibility shim until ResourceChange is expected by all callers.

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -58,7 +58,7 @@ func (c *ResourceChange) Kind() string {
 }
 
 // ComposeTF12Resources is a thin wrapper around ReadResourceChanges as a compatibility shim.
-func ComposeTF12Resources(data []byte, schemas map[string]*schema.Resource) ([]ResourceChange, error) {
+func ComposeTF12Resources(data []byte, _ map[string]*schema.Resource) ([]ResourceChange, error) {
 	return ReadResourceChanges(data)
 }
 

--- a/tfplan/json_plan_test.go
+++ b/tfplan/json_plan_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPlan(t *testing.T) jsonPlan {
+func newPlan(t *testing.T) []byte {
 	t.Helper()
-	data := []byte(`
+	return []byte(`
 {
   "planned_values": {
     "root_module": {
@@ -36,7 +36,7 @@ func newPlan(t *testing.T) jsonPlan {
 								{
 									"address": "module.foo.bar.google_compute_instance.quz4",
 									"values": {"key4": "value4"}
-								}  
+								}
               ]
             }
           ]
@@ -47,6 +47,10 @@ func newPlan(t *testing.T) jsonPlan {
 	"resource_changes": [
 		{
 			"address": "module.foo.google_compute_instance.quz1",
+			"mode": "managed",
+			"type": "google_compute_instance",
+			"name": "quz1",
+			"provider_name": "google",
 			"change": {
 				"actions": ["delete", "create"],
 				"before": {"key1": "value1"},
@@ -58,6 +62,10 @@ func newPlan(t *testing.T) jsonPlan {
 		},
 		{
 			"address": "module.foo.bar.google_compute_instance.quz2",
+			"mode": "managed",
+			"type": "google_compute_instance",
+			"name": "quz2",
+			"provider_name": "google",
 			"change": {
 				"actions": ["noop"],
 				"before": {"key2": "value2"},
@@ -66,68 +74,95 @@ func newPlan(t *testing.T) jsonPlan {
 		},
 		{
 			"address": "module.foo.bar.google_compute_instance.quz3",
+			"mode": "managed",
+			"type": "google_compute_instance",
+			"name": "quz3",
+			"provider_name": "google",
 			"change": {
 				"actions": ["delete"],
 				"before": {"key3": "value3"},
 				"after": {}
 			}
-		},  
+		},
 		{
 			"address": "module.foo.bar.google_compute_instance.quz4",
+			"mode": "managed",
+			"type": "google_compute_instance",
+			"name": "quz4",
+			"provider_name": "google",
 			"change": {
 				"actions": ["create"],
 				"before": {},
 				"after": {"key4": "value4"}
 			}
-		}  
+		}
 	]
 }
 `)
-	plan := jsonPlan{}
-	err := json.Unmarshal(data, &plan)
+}
+
+func TestReadResourceChanges(t *testing.T) {
+	wantJSON := []byte(`
+[
+	{
+		"address": "module.foo.google_compute_instance.quz1",
+		"mode": "managed",
+		"type": "google_compute_instance",
+		"name": "quz1",
+		"provider_name": "google",
+		"change": {
+			"actions": ["delete", "create"],
+			"before": {"key1": "value1"},
+			"after": {
+				"key1": "value1",
+				"nestedKey1": { "insideKey1": "insideValue1"}
+			}
+		}
+	},
+	{
+		"address": "module.foo.bar.google_compute_instance.quz2",
+		"mode": "managed",
+		"type": "google_compute_instance",
+		"name": "quz2",
+		"provider_name": "google",
+		"change": {
+			"actions": ["noop"],
+			"before": {"key2": "value2"},
+			"after": {"key2": "value2"}
+		}
+	},
+	{
+		"address": "module.foo.bar.google_compute_instance.quz3",
+		"mode": "managed",
+		"type": "google_compute_instance",
+		"name": "quz3",
+		"provider_name": "google",
+		"change": {
+			"actions": ["delete"],
+			"before": {"key3": "value3"},
+			"after": {}
+		}
+	},
+	{
+		"address": "module.foo.bar.google_compute_instance.quz4",
+		"mode": "managed",
+		"type": "google_compute_instance",
+		"name": "quz4",
+		"provider_name": "google",
+		"change": {
+			"actions": ["create"],
+			"before": {},
+			"after": {"key4": "value4"}
+		}
+	}
+]
+`)
+	data := newPlan(t)
+	rcs, err := ReadResourceChanges(data)
 	if err != nil {
 		t.Fatalf("parsing %s: %v", string(data), err)
 	}
-	return plan
-}
-
-func TestReadPlannedJSONResources(t *testing.T) {
-	wantJSON := []byte(`
-[
-  {
-    "address": "module.foo.google_compute_instance.quz1",
-    "mode": "",
-    "module": "foo",
-    "name": "",
-    "provider_name": "",
-    "type": "",
-		"values": {
-			"key1": "value1",
-			"nestedKey1": { "insideKey1": "insideValue1"}
-		}
-  },
-  {
-    "address": "module.foo.bar.google_compute_instance.quz2",
-    "mode": "",
-    "module": "foo.bar",
-    "name": "",
-    "provider_name": "",
-    "type": "",
-		"values": {"key2": "value2"}
-  },
-  {
-    "address": "module.foo.bar.google_compute_instance.quz4",
-    "mode": "",
-    "module": "foo.bar",
-    "name": "",
-    "provider_name": "",
-    "type": "",
-		"values": {"key4": "value4"}
-  }
-]
-`)
-	got := readPlannedJSONResources(newPlan(t))
-	gotJSON, err := json.Marshal(got)
+	gotJSON, err := json.Marshal(rcs)
 	if err != nil {
 		t.Fatalf("marshaling: %v", err)
 	}


### PR DESCRIPTION
The goal of this PR is to start operating on ResourceChanges, as the next step towards having the converter be able to convert and merge deletions of IAM resources. For this step, the focus is on changing just the data format passed to the converter and leaving the exposed API intact – specifically, maintaining the compatibility described [here](https://docs.google.com/document/d/1_FDdCuqs3hpaceZRXnKfJJ0VgdsJzuKYsmOEA0AZIi8/edit#heading=h.gijrsdjw51q5). ResourceChange reading is simpler because [the data is a simple list instead of a nested structure](https://www.terraform.io/docs/internals/json-format.html#plan-representation).

This is related to https://github.com/hashicorp/terraform-provider-google/issues/7797