### PR TITLE
Fully moved responsibility for iterating over and filtering resource changes to converter

### DIFF
--- a/converters/google/fake_resource_data.go
+++ b/converters/google/fake_resource_data.go
@@ -71,6 +71,13 @@ func (d *FakeResourceData) GetOkExists(name string) (interface{}, bool) {
 	return d.GetOk(name)
 }
 
+// These methods are required by some mappers but we don't actually have (or need)
+// implementations for them.
+func (d *FakeResourceData) HasChange(string) bool             { return false }
+func (d *FakeResourceData) Set(string, interface{}) error     { return nil }
+func (d *FakeResourceData) SetId(string)                      {}
+func (d *FakeResourceData) GetProviderMeta(interface{}) error { return nil }
+
 func NewFakeResourceData(kind string, resourceSchema map[string]*schema.Schema, values map[string]interface{}) FakeResourceData {
 	state := map[string]string{}
 	var address []string

--- a/tfplan/json_plan.go
+++ b/tfplan/json_plan.go
@@ -26,25 +26,27 @@ type jsonPlan struct {
 	ResourceChanges []ResourceChange `json:"resource_changes"`
 }
 
+type ChangeRepresentation struct {
+	// Valid actions values are:
+	//    ["no-op"]
+	//    ["create"]
+	//    ["read"]
+	//    ["update"]
+	//    ["delete", "create"]
+	//    ["create", "delete"]
+	//    ["delete"]
+	Actions []string               `json:"actions"`
+	Before  map[string]interface{} `json:"before"`
+	After   map[string]interface{} `json:"after"`
+}
+
 type ResourceChange struct {
-	Address      string `json:"address"`
-	Mode         string `json:"mode"`
-	Type         string `json:"type"`
-	Name         string `json:"name"`
-	ProviderName string `json:"provider_name"`
-	Change       struct {
-		// Valid actions values are:
-		//    ["no-op"]
-		//    ["create"]
-		//    ["read"]
-		//    ["update"]
-		//    ["delete", "create"]
-		//    ["create", "delete"]
-		//    ["delete"]
-		Actions []string               `json:"actions"`
-		Before  map[string]interface{} `json:"before"`
-		After   map[string]interface{} `json:"after"`
-	} `json:"change"`
+	Address      string               `json:"address"`
+	Mode         string               `json:"mode"`
+	Type         string               `json:"type"`
+	Name         string               `json:"name"`
+	ProviderName string               `json:"provider_name"`
+	Change       ChangeRepresentation `json:"change"`
 }
 
 func (c *ResourceChange) IsCreate() bool {


### PR DESCRIPTION
This change allows the converter to filter out unsupported resource changes (this was partially handled by `tfplan.jsonToResources` prior to #176) and to have a specific internal function that is only responsible for adding a resource change that is known to be a create or update to the converter's internal asset map (which means we will be able to have a separate internal function to handle merging in deletes, and a separate internal function for pre-fetching things like IAM.)

This is slightly different than the design doc, which called for detecting create&update vs delete inside AddResourceChange; however, I think this is a better separation of concerns.