### PR TITLE
Switched to using terraform-json for plan parsing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4
+	github.com/hashicorp/terraform-json v0.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.3.0
 	github.com/hashicorp/terraform-provider-google/v3 v3.0.0-20201214235032-2215c9d53d99
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -511,6 +511,7 @@ github.com/hashicorp/terraform-exec v0.10.0 h1:3nh/1e3u9gYRUQGOKWp/8wPR7ABlL2F14
 github.com/hashicorp/terraform-exec v0.10.0/go.mod h1:tOT8j1J8rP05bZBGWXfMyU3HkLi1LWyqL3Bzsc3CJjo=
 github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f0wvREtyzs=
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
+github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
 github.com/hashicorp/terraform-plugin-go v0.1.0 h1:kyXZ0nkHxiRev/q18N40IbRRk4AV0zE/MDJkDM3u8dY=
 github.com/hashicorp/terraform-plugin-go v0.1.0/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=

--- a/tfplan/json_plan_test.go
+++ b/tfplan/json_plan_test.go
@@ -11,6 +11,7 @@ func newPlan(t *testing.T) []byte {
 	t.Helper()
 	return []byte(`
 {
+  "format_version": "0.1",
   "planned_values": {
     "root_module": {
       "child_modules": [


### PR DESCRIPTION
This is the official library provided by Hashicorp, so it gives us more coverage out of the box and will provide an upgrade path for new export formats in the future.

Specific new functionality we may want shortly is being able to stop importing terraform-provider-google and instead relying on Schema exports. For context, see https://www.terraform.io/docs/extend/best-practices/versioning.html