### PR TITLE
returns ErrDuplicateAsset wrapped by a new error so that errors.Cause works

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -302,7 +302,7 @@ func (c *Converter) addCreateOrUpdate(rc *tfjson.ResourceChange) error {
 				if mapper.mergeCreateUpdate == nil {
 					// If a merge function does not exist ignore the asset and return
 					// a checkable error.
-					return fmt.Errorf("asset type %s: asset name %s %w", converted.Type, converted.Name, ErrDuplicateAsset)
+					return errors.Wrapf(ErrDuplicateAsset, "asset type %s: asset name %s", converted.Type, converted.Name)
 				}
 				converted = mapper.mergeCreateUpdate(*existingConverterAsset, converted)
 			}


### PR DESCRIPTION
This PR Closes https://github.com/GoogleCloudPlatform/terraform-validator/issues/196

TODO:
- [x] Add unit test for the issue

The converter does a check by the cause of an error and just logs a warning if the error cause is `ErrDuplicateAsset `

https://github.com/GoogleCloudPlatform/terraform-validator/blob/6a9552f3f4c079b6c6abd1a53fc4f51f477beb8e/converters/google/convert.go#L203

```go
if errors.Cause(err) == ErrDuplicateAsset {
	glog.Warningf("adding resource change: %v", err)
} else {
``` 

in previous versions, this error was create as:

```go
return errors.Wrapf(ErrDuplicateAsset, "asset type %s: asset name %s", converted.Type, converted.Name)
```

but now it is using:

```go
return fmt.Errorf("asset type %s: asset name %s %w", converted.Type, converted.Name, ErrDuplicateAsset)
```

which does not wrap the error but creates a new error using only the "error message" from the original error.

this PR reverts the code to its previous version

Result with the new version in the test file from the issue(reformatted for clarity):

` ./bin/terraform-validator convert ../two_project_with_budget/tst.json --project=<REDACTED>`

```console
ERROR: logging before flag.Parse: I0318 16:53:12.402048    5683 convert.go:188] unsupported resource: google_billing_budget
ERROR: logging before flag.Parse: I0318 16:53:12.402104    5683 convert.go:188] unsupported resource: google_billing_budget
ERROR: logging before flag.Parse: I0318 16:53:12.402114    5683 convert.go:182] unknown resource: random_id
ERROR: logging before flag.Parse: W0318 16:53:13.708944    5683 convert.go:204] adding resource change: asset type cloudbilling.googleapis.com/ProjectBillingInfo: asset name //cloudbilling.googleapis.com/projects/<REDACTED>/billingInfo: duplicate asset
[
    {
        "name": "//cloudbilling.googleapis.com/projects/<REDACTED>/billingInfo",
        "asset_type": "cloudbilling.googleapis.com/ProjectBillingInfo",
        "ancestry_path": "organization/<REDACTED>/folder/146035178388/folder/220237755881/project/<REDACTED>",
        "resource": {
            "version": "v1",
            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/cloudbilling/v1/rest",
            "discovery_name": "ProjectBillingInfo",
            "parent": "//cloudresourcemanager.googleapis.com/projects/<REDACTED>",
            "data": {
                "billingAccountName": "billingAccounts/<REDACTED>",
                "name": "projects//billingInfo"
            }
        }
    },
    {
        "name": "//cloudresourcemanager.googleapis.com/projects/<REDACTED>",
        "asset_type": "cloudresourcemanager.googleapis.com/Project",
        "ancestry_path": "organization/<REDACTED>/folder/146035178388/folder/220237755881/project/<REDACTED>",
        "resource": {
            "version": "v1",
            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
            "discovery_name": "Project",
            "parent": "//cloudresourcemanager.googleapis.com/projects/<REDACTED>",
            "data": {
                "name": "My Project2",
                "parent": {
                    "id": "<REDACTED>",
                    "type": "organization"
                }
            }
        }
    }
]
```