### PR TITLE
add handling of empty versioning and cors in storage bucket from TGC

### DIFF
--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -352,3 +352,52 @@ func TestAddDuplicatedResources(t *testing.T) {
 	caiKeyProject := "cloudresourcemanager.googleapis.com/Project//cloudresourcemanager.googleapis.com/projects/test-project"
 	assert.Contains(t, c.assets, caiKeyProject)
 }
+
+func TestAddStorageModuleAfterUnknown(t *testing.T) {
+	var nilValue map[string]interface{} = nil
+	rc := tfjson.ResourceChange{
+		Address:       "module.gcs_buckets.google_storage_bucket.buckets[0]",
+		ModuleAddress: "module.gcs_buckets",
+		Mode:          "managed",
+		Type:          "google_storage_bucket",
+		Name:          "buckets",
+		Index:         0,
+		ProviderName:  "google",
+		Change: &tfjson.Change{
+			Actions: tfjson.Actions{"create"},
+			Before:  nil,
+			After: map[string]interface{}{
+				"cors": []interface{}{
+					nilValue,
+				},
+				"default_event_based_hold": nil,
+				"encryption": []interface{}{
+					nilValue,
+				},
+				"lifecycle_rule":   []interface{}{},
+				"location":         "US",
+				"logging":          []interface{}{},
+				"project":          "test-project",
+				"requester_pays":   nil,
+				"retention_policy": []interface{}{},
+				"storage_class":    "MULTI_REGIONAL",
+				"versioning": []interface{}{
+					nilValue,
+				},
+				"website": []interface{}{
+					nilValue,
+				},
+			},
+		},
+	}
+	c, err := newTestConverter()
+	assert.Nil(t, err)
+
+	err = c.AddResourceChanges([]*tfjson.ResourceChange{&rc})
+	assert.Nil(t, err)
+	assert.Len(t, c.assets, 1)
+	for key := range c.assets {
+		assert.EqualValues(t, c.assets[key].Type, "storage.googleapis.com/Bucket")
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210318171059-9ab40040d220
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210319162701-45d07ba9aed4
 	github.com/forseti-security/config-validator v0.0.0-20200812033229-7388761cc9ca
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210311162721
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210311162721-d97a3783d011/go.mod h1:ZmY0Ua5EVNaxHXJe5x3VQfaghzCmORy2fksFH4Wf6Eg=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210318171059-9ab40040d220 h1:jst9/iXj83wIXE8kvzy6jTo37ZYpabY5hvNe2brKa9Q=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210318171059-9ab40040d220/go.mod h1:ZmY0Ua5EVNaxHXJe5x3VQfaghzCmORy2fksFH4Wf6Eg=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210319162701-45d07ba9aed4 h1:mnfuVLq9UEYOi3ERSLH9PwV9JCJA+pe0hnlOvhS1roc=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210319162701-45d07ba9aed4/go.mod h1:ZmY0Ua5EVNaxHXJe5x3VQfaghzCmORy2fksFH4Wf6Eg=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
This PR Closes https://github.com/GoogleCloudPlatform/terraform-validator/issues/201

The bump in the `terraform-google-conversion` version pull from terraform-google-conversion this fix:

https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/661/commits/c97b59312fd5af32c30d50f9f866978a52ea4ca3

