### PR TITLE
Improved error messages returned for failure to have a project set

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -338,11 +338,11 @@ func (c *Converter) Assets() []Asset {
 func (c *Converter) augmentAsset(tfData converter.TerraformResourceData, cfg *converter.Config, cai converter.Asset) (Asset, error) {
 	project, err := getProject(tfData, cfg, cai)
 	if err != nil {
-		return Asset{}, err
+		return Asset{}, fmt.Errorf("getting project for %v: %w", cai.Name, err)
 	}
 	ancestry, err := c.ancestryManager.GetAncestryWithResource(project, tfData, cai)
 	if err != nil {
-		return Asset{}, fmt.Errorf("getting resource ancestry: project %v %w", project, err)
+		return Asset{}, fmt.Errorf("getting resource ancestry for project %v: %w", project, err)
 	}
 	var resource *AssetResource
 	if cai.Resource != nil {

--- a/converters/google/vendor_utils.go
+++ b/converters/google/vendor_utils.go
@@ -54,5 +54,5 @@ func getProjectFromSchema(projectSchemaField string, d converter.TerraformResour
 	if config.Project != "" {
 		return config.Project, nil
 	}
-	return "", fmt.Errorf("%s: required field is not set", projectSchemaField)
+	return "", fmt.Errorf("required field '%s' is not set", projectSchemaField)
 }


### PR DESCRIPTION
Standardized on the format of `new error message: wrapped error message` - previously, some of the messages were `new error: message wrapped error message`.

Also, added marker of what CAI resource is missing project id, to make debugging easier.