### PR TITLE
Add mergeDelete support for org / folder

### DIFF
--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -94,12 +94,16 @@ func mappers() map[string][]mapper {
 			{
 				convert:           converter.GetOrganizationIamBindingCaiObject,
 				mergeCreateUpdate: converter.MergeOrganizationIamBinding,
+				mergeDelete:       converter.MergeOrganizationIamBindingDelete,
+				fetch:             converter.FetchOrganizationIamPolicy,
 			},
 		},
 		"google_organization_iam_member": {
 			{
 				convert:           converter.GetOrganizationIamMemberCaiObject,
 				mergeCreateUpdate: converter.MergeOrganizationIamMember,
+				mergeDelete:       converter.MergeOrganizationIamMemberDelete,
+				fetch:             converter.FetchOrganizationIamPolicy,
 			},
 		},
 		"google_folder_iam_policy": {
@@ -112,12 +116,16 @@ func mappers() map[string][]mapper {
 			{
 				convert:           converter.GetFolderIamBindingCaiObject,
 				mergeCreateUpdate: converter.MergeFolderIamBinding,
+				mergeDelete:       converter.MergeFolderIamBindingDelete,
+				fetch:             converter.FetchFolderIamPolicy,
 			},
 		},
 		"google_folder_iam_member": {
 			{
 				convert:           converter.GetFolderIamMemberCaiObject,
 				mergeCreateUpdate: converter.MergeFolderIamMember,
+				mergeDelete:       converter.MergeFolderIamMemberDelete,
+				fetch:             converter.FetchFolderIamPolicy,
 			},
 		},
 		"google_project_iam_policy": {

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -98,11 +98,15 @@ func TestCLI(t *testing.T) {
 
 	// Map of cases to skip to reasons for the skip
 	skipCases := map[string]string{
-		"TestCLI/v=0.12/tf=example_compute_instance/offline=true/cmd=convert":                                   "compute_instance doesn't work in offline mode - github.com/hashicorp/terraform-provider-google/issues/8489",
-		"TestCLI/v=0.12/tf=example_compute_instance/offline=true/cmd=validate/constraint=always_violate":        "compute_instance doesn't work in offline mode - github.com/hashicorp/terraform-provider-google/issues/8489",
-		"TestCLI/v=0.12/tf=example_project_iam/offline=false/cmd=convert":                                       "example_project_iam is too complex to untangle merges with online data generically",
-		"TestCLI/v=0.12/tf=example_compute_forwarding_rule/offline=true/cmd=convert":                            "temperarily skip because of the predictable drift in offline mode",
-		"TestCLI/v=0.12/tf=example_compute_forwarding_rule/offline=true/cmd=validate/constraint=always_violate": "temperarily skip because of the predictable drift in offline mode",
+		"TestCLI/v=0.12/tf=example_compute_forwarding_rule/offline=true/cmd=convert":                              "temperarily skip because of the predictable drift in offline mode",
+		"TestCLI/v=0.12/tf=example_compute_forwarding_rule/offline=true/cmd=validate/constraint=always_violate":   "temperarily skip because of the predictable drift in offline mode",
+		"TestCLI/v=0.12/tf=example_compute_instance/offline=true/cmd=convert":                                     "compute_instance doesn't work in offline mode - github.com/hashicorp/terraform-provider-google/issues/8489",
+		"TestCLI/v=0.12/tf=example_compute_instance/offline=true/cmd=validate/constraint=always_violate":          "compute_instance doesn't work in offline mode - github.com/hashicorp/terraform-provider-google/issues/8489",
+		"TestCLI/v=0.12/tf=example_organization_iam_binding/offline=false/cmd=convert":                            "skip because test runner doesn't have org permissions",
+		"TestCLI/v=0.12/tf=example_organization_iam_binding/offline=false/cmd=validate/constraint=always_violate": "skip because test runner doesn't have org permissions",
+		"TestCLI/v=0.12/tf=example_organization_iam_member/offline=false/cmd=convert":                             "skip because test runner doesn't have org permissions",
+		"TestCLI/v=0.12/tf=example_organization_iam_member/offline=false/cmd=validate/constraint=always_violate":  "skip because test runner doesn't have org permissions",
+		"TestCLI/v=0.12/tf=example_project_iam/offline=false/cmd=convert":                                         "example_project_iam is too complex to untangle merges with online data generically",
 	}
 	for i := range cases {
 		// Allocate a variable to make sure test can run in parallel.
@@ -141,7 +145,7 @@ func TestCLI(t *testing.T) {
 				if tfstateMatches != nil {
 					generateTestFiles(t, "../testdata/templates", dir, c.name+".tfstate")
 					err = os.Rename(
-						filepath.Join(dir, c.name + ".tfstate"),
+						filepath.Join(dir, c.name+".tfstate"),
 						filepath.Join(dir, "terraform.tfstate"),
 					)
 					if err != nil {


### PR DESCRIPTION
Added the mergeDelete functions to the mappers for org / folder IAM. Related to https://github.com/hashicorp/terraform-provider-google/issues/7797

Ultimately, the integration tests don't actually verify that merge delete works properly, because that would require being able to fake the results of a mapper.fetch() call (and/or be able to modify the organization and folder being tested), which is outside the scope of this ticket. However, we do have tests in terraform-google-conversion for merge deletion behavior. The code can be manually tested using the following process (if you have access to change a folder / org):

1. Create a terraform file that adds a binding or member to your test project.
2. Apply the file.
3. Remove the binding / member from the file.
4. Run `terraform plan --out tfplan.tfplan`
5. Run `terraform show -json ./tfplan.tfplan > ./tfplan.json`
6. Run `/path/to/terraform-validator/bin/terraform-validator convert ./tfplan.json --project=project_id`

Specifying `--project=project_id` is unfortunately necessary because of https://github.com/GoogleCloudPlatform/terraform-validator/issues/206

(Merge deletion behavior may be easier to verify manually with [project](https://github.com/GoogleCloudPlatform/terraform-validator/pull/180)/[storage bucket](https://github.com/GoogleCloudPlatform/terraform-validator/pull/207); the underlying code is basically the same for folder/org, just a different way to fetch the policy.)