### PR TITLE
Add support for google_compute_network and google_compute_subnetwork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.14
 RUN apt-get update && apt-get -y install wget unzip
 
 WORKDIR /tmp
-RUN wget https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip && unzip terraform_0.12.20_linux_amd64.zip -d /usr/local/bin
+RUN wget https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip && unzip terraform_0.12.24_linux_amd64.zip -d /usr/local/bin
 
 
 ENV GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ google_compute_forwarding_rule
 google_compute_global_forwarding_rule
 google_compute_firewall
 google_compute_instance
+google_compute_network
 google_container_cluster
 google_container_node_pool
 google_filestore_instance

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ google_compute_global_forwarding_rule
 google_compute_firewall
 google_compute_instance
 google_compute_network
+google_compute_subnetwork
 google_container_cluster
 google_container_node_pool
 google_filestore_instance

--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -56,6 +56,7 @@ func mappers() map[string][]mapper {
 		"google_compute_global_forwarding_rule": {{convert: converter.GetComputeGlobalForwardingRuleCaiObject}},
 		"google_compute_instance":               {{convert: converter.GetComputeInstanceCaiObject}},
 		"google_compute_network":                {{convert: converter.GetComputeNetworkCaiObject}},
+		"google_compute_subnetwork":             {{convert: converter.GetComputeSubnetworkCaiObject}},
 		"google_storage_bucket":                 {{convert: converter.GetStorageBucketCaiObject}},
 		"google_sql_database_instance":          {{convert: converter.GetSQLDatabaseInstanceCaiObject}},
 		"google_container_cluster":              {{convert: converter.GetContainerClusterCaiObject}},

--- a/converters/google/mappers.go
+++ b/converters/google/mappers.go
@@ -55,6 +55,7 @@ func mappers() map[string][]mapper {
 		"google_compute_forwarding_rule":        {{convert: converter.GetComputeForwardingRuleCaiObject}},
 		"google_compute_global_forwarding_rule": {{convert: converter.GetComputeGlobalForwardingRuleCaiObject}},
 		"google_compute_instance":               {{convert: converter.GetComputeInstanceCaiObject}},
+		"google_compute_network":                {{convert: converter.GetComputeNetworkCaiObject}},
 		"google_storage_bucket":                 {{convert: converter.GetStorageBucketCaiObject}},
 		"google_sql_database_instance":          {{convert: converter.GetSQLDatabaseInstanceCaiObject}},
 		"google_container_cluster":              {{convert: converter.GetContainerClusterCaiObject}},

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -65,6 +65,7 @@ func TestCLI(t *testing.T) {
 		{name: "example_compute_firewall"},
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_instance"},
+		{name: "example_compute_network"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},
 		{name: "example_filestore_instance"},

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -66,6 +66,7 @@ func TestCLI(t *testing.T) {
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_instance"},
 		{name: "example_compute_network"},
+		{name: "example_compute_subnetwork"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},
 		{name: "example_filestore_instance"},

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -29,6 +29,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_compute_disk"},
 		{name: "example_compute_firewall"},
 		{name: "example_compute_instance"},
+		{name: "example_compute_network"},
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -30,6 +30,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_compute_firewall"},
 		{name: "example_compute_instance"},
 		{name: "example_compute_network"},
+		{name: "example_compute_subnetwork"},
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},

--- a/testdata/templates/example_compute_firewall.json
+++ b/testdata/templates/example_compute_firewall.json
@@ -34,5 +34,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/test-network",
+    "asset_type": "compute.googleapis.com/Network",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Network",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "autoCreateSubnetworks": true,
+        "name": "test-network"
+      }
+    }
   }
 ]

--- a/testdata/templates/example_compute_network.json
+++ b/testdata/templates/example_compute_network.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/test-network",
+    "asset_type": "compute.googleapis.com/Network",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Network",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "autoCreateSubnetworks": false,
+        "name": "test-network"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_compute_network.tf
+++ b/testdata/templates/example_compute_network.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_network" "default" {
+  name = "test-network"
+  auto_create_subnetworks = false
+}

--- a/testdata/templates/example_compute_network.tfplan.json
+++ b/testdata/templates/example_compute_network.tfplan.json
@@ -1,0 +1,87 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.24",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_network.default",
+          "mode": "managed",
+          "type": "google_compute_network",
+          "name": "default",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": null,
+            "name": "test-network",
+            "timeouts": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_network.default",
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "default",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "auto_create_subnetworks": false,
+          "delete_default_routes_on_create": false,
+          "description": null,
+          "name": "test-network",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "gateway_ipv4": true,
+          "id": true,
+          "mtu": true,
+          "project": true,
+          "routing_mode": true,
+          "self_link": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": "{{.Provider.project}}"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_network.default",
+          "mode": "managed",
+          "type": "google_compute_network",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "auto_create_subnetworks": {
+              "constant_value": false
+            },
+            "name": {
+              "constant_value": "test-network"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/testdata/templates/example_compute_subnetwork.json
+++ b/testdata/templates/example_compute_subnetwork.json
@@ -1,0 +1,41 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/test-network",
+    "asset_type": "compute.googleapis.com/Network",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Network",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "autoCreateSubnetworks": false,
+        "name": "test-network"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/regions/us-central1/subnetworks/my-test-subnetwork",
+    "asset_type": "compute.googleapis.com/Subnetwork",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Subnetwork",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "ipCidrRange": "10.0.0.0/24",
+        "logConfig": {
+          "aggregationInterval": "INTERVAL_10_MIN",
+          "enable": true,
+          "filterExpr": "true",
+          "flowSampling": 0.5,
+          "metadata": "INCLUDE_ALL_METADATA",
+          "metadataFields": []
+        },
+        "name": "my-test-subnetwork",
+        "region": "projects/{{.Provider.project}}/global/regions/us-central1"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_compute_subnetwork.tf
+++ b/testdata/templates/example_compute_subnetwork.tf
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_network" "default" {
+  name = "test-network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "my-test-subnetwork" {
+  name          = "my-test-subnetwork"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
+}

--- a/testdata/templates/example_compute_subnetwork.tfplan.json
+++ b/testdata/templates/example_compute_subnetwork.tfplan.json
@@ -1,0 +1,188 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.24",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_network.default",
+          "mode": "managed",
+          "type": "google_compute_network",
+          "name": "default",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": null,
+            "name": "test-network",
+            "timeouts": null
+          }
+        },
+        {
+          "address": "google_compute_subnetwork.my-test-subnetwork",
+          "mode": "managed",
+          "type": "google_compute_subnetwork",
+          "name": "my-test-subnetwork",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "ip_cidr_range": "10.0.0.0/24",
+            "log_config": [
+              {
+                "aggregation_interval": "INTERVAL_10_MIN",
+                "filter_expr": "true",
+                "flow_sampling": 0.5,
+                "metadata": "INCLUDE_ALL_METADATA",
+                "metadata_fields": null
+              }
+            ],
+            "name": "my-test-subnetwork",
+            "private_ip_google_access": null,
+            "region": "us-central1",
+            "timeouts": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_network.default",
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "default",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "auto_create_subnetworks": false,
+          "delete_default_routes_on_create": false,
+          "description": null,
+          "name": "test-network",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "gateway_ipv4": true,
+          "id": true,
+          "mtu": true,
+          "project": true,
+          "routing_mode": true,
+          "self_link": true
+        }
+      }
+    },
+    {
+      "address": "google_compute_subnetwork.my-test-subnetwork",
+      "mode": "managed",
+      "type": "google_compute_subnetwork",
+      "name": "my-test-subnetwork",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "ip_cidr_range": "10.0.0.0/24",
+          "log_config": [
+            {
+              "aggregation_interval": "INTERVAL_10_MIN",
+              "filter_expr": "true",
+              "flow_sampling": 0.5,
+              "metadata": "INCLUDE_ALL_METADATA",
+              "metadata_fields": null
+            }
+          ],
+          "name": "my-test-subnetwork",
+          "private_ip_google_access": null,
+          "region": "us-central1",
+          "timeouts": null
+        },
+        "after_unknown": {
+          "creation_timestamp": true,
+          "fingerprint": true,
+          "gateway_address": true,
+          "id": true,
+          "log_config": [
+            {}
+          ],
+          "network": true,
+          "private_ipv6_google_access": true,
+          "project": true,
+          "secondary_ip_range": true,
+          "self_link": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_network.default",
+          "mode": "managed",
+          "type": "google_compute_network",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "auto_create_subnetworks": {
+              "constant_value": false
+            },
+            "name": {
+              "constant_value": "test-network"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_compute_subnetwork.my-test-subnetwork",
+          "mode": "managed",
+          "type": "google_compute_subnetwork",
+          "name": "my-test-subnetwork",
+          "provider_config_key": "google",
+          "expressions": {
+            "ip_cidr_range": {
+              "constant_value": "10.0.0.0/24"
+            },
+            "log_config": [
+              {
+                "aggregation_interval": {
+                  "constant_value": "INTERVAL_10_MIN"
+                },
+                "flow_sampling": {
+                  "constant_value": 0.5
+                },
+                "metadata": {
+                  "constant_value": "INCLUDE_ALL_METADATA"
+                }
+              }
+            ],
+            "name": {
+              "constant_value": "my-test-subnetwork"
+            },
+            "network": {
+              "references": [
+                "google_compute_network.default"
+              ]
+            },
+            "region": {
+              "constant_value": "us-central1"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/testdata/templates/full_compute_firewall.json
+++ b/testdata/templates/full_compute_firewall.json
@@ -114,5 +114,20 @@
         ]
       }
     }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/test-network",
+    "asset_type": "compute.googleapis.com/Network",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Network",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "autoCreateSubnetworks": true,
+        "name": "test-network"
+      }
+    }
   }
 ]

--- a/testdata/templates/full_sql_database_instance.json
+++ b/testdata/templates/full_sql_database_instance.json
@@ -90,5 +90,20 @@
         }
       }
     }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/private-network",
+    "asset_type": "compute.googleapis.com/Network",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Network",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "autoCreateSubnetworks": true,
+        "name": "private-network"
+      }
+    }
   }
 ]


### PR DESCRIPTION
Adds support for the `google_compute_network` (#20, #211) and `google_compute_subnetwork` (#20) resource types.

Note: The integration tests failed for me when running within the Docker container (`make build-docker`, `make run-docker`, `make test-integration`) because the `Dockerfile` is installing [Terraform `0.12.20`](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/Dockerfile#L6), but one of the tests expects [Terraform `0.12.24`](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/testdata/templates/example_project_update.tfstate#L3). I updated the version in the `Dockerfile` to install `0.12.24` to get around this issue. Not sure if that impacts any other tests/dependencies, or if we should jump to the latest Terraform `0.12.x` version (`0.12.31` as of Jun 6, 2021)?

It seems like `terraform-google-conversion` supports a large number of resources already, so I didn't update that dependency. Assuming we don't have to update it for the ones listed at https://github.com/GoogleCloudPlatform/terraform-google-conversion/tree/master/google, and these changes cover everything required for additional resource types, I may add others that I would like to validate against that aren't currently supported.

Resolved #20. Resolved #211.