### PR TITLE
Skip flakey read test

### DIFF
--- a/test/read_test.go
+++ b/test/read_test.go
@@ -53,7 +53,8 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_storage_bucket"},
 		{name: "example_storage_bucket_iam_binding"},
 		{name: "example_storage_bucket_iam_member"},
-		{name: "example_storage_bucket_iam_member_random_suffix"},
+		// This test is flakey - see https://github.com/GoogleCloudPlatform/terraform-validator/issues/259
+		// {name: "example_storage_bucket_iam_member_random_suffix"},
 		{name: "example_storage_bucket_iam_policy"},
 		{name: "full_compute_firewall"},
 		{name: "full_compute_instance"},


### PR DESCRIPTION
This wasn't previously an issue because read tests were never run