### PR TITLE
Synced provider credential initialization to be in line with tpg/b

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -127,11 +127,24 @@ type RestoreDefault struct {
 }
 
 // NewConverter is a factory function for Converter.
-func NewConverter(ctx context.Context, ancestryManager ancestrymanager.AncestryManager, project, credentials string, offline bool) (*Converter, error) {
+func NewConverter(ctx context.Context, ancestryManager ancestrymanager.AncestryManager, project string, offline bool) (*Converter, error) {
 	cfg := &converter.Config{
-		Project:     project,
-		Credentials: credentials,
+		Project: project,
 	}
+
+	if !offline {
+		// Search for default credentials
+		cfg.Credentials = multiEnvSearch([]string{
+			"GOOGLE_CREDENTIALS",
+			"GOOGLE_CLOUD_KEYFILE_JSON",
+			"GCLOUD_KEYFILE_JSON",
+		})
+
+		cfg.AccessToken = multiEnvSearch([]string{
+			"GOOGLE_OAUTH_ACCESS_TOKEN",
+		})
+	}
+
 	if !offline {
 		converter.ConfigureBasePaths(cfg)
 		if err := cfg.LoadAndValidate(ctx); err != nil {

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -36,7 +36,7 @@ func newTestConverter() (*Converter, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource manager client")
 	}
-	c, err := NewConverter(ctx, ancestryManager, project, "", offline)
+	c, err := NewConverter(ctx, ancestryManager, project, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "building converter")
 	}

--- a/converters/google/vendor_utils.go
+++ b/converters/google/vendor_utils.go
@@ -17,6 +17,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"os"
 
 	converter "github.com/GoogleCloudPlatform/terraform-google-conversion/google"
 )
@@ -63,4 +64,13 @@ func getProjectFromSchema(projectSchemaField string, d converter.TerraformResour
 		return config.Project, nil
 	}
 	return "", fmt.Errorf("required field '%s' is not set", projectSchemaField)
+}
+
+func multiEnvSearch(ks []string) string {
+	for _, k := range ks {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
 }

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -62,7 +62,7 @@ func newConverter(ctx context.Context, path, project, ancestry string, offline b
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource manager client")
 	}
-	converter, err := google.NewConverter(ctx, ancestryManager, project, "", offline)
+	converter, err := google.NewConverter(ctx, ancestryManager, project, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google converter")
 	}


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/terraform-validator/issues/279

credentials/token were not being initialized from before calling `LoadAndValidate`. 

see https://github.com/hashicorp/terraform-provider-google/blob/master/google/provider.go#L1270-L1279 for tpg/b implementation.