### PR TITLE
Fixed logging before flag.parse error

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,8 +14,18 @@
 
 package main
 
-import "github.com/GoogleCloudPlatform/terraform-validator/cmd"
+import (
+	"flag"
+
+	"github.com/GoogleCloudPlatform/terraform-validator/cmd"
+)
 
 func main() {
+	// Workaround for "ERROR: logging before flag.Parse"
+	// See https://github.com/GoogleCloudPlatform/terraform-validator/issues/122
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	_ = fs.Parse([]string{})
+	flag.CommandLine = fs
+
 	cmd.Execute()
 }


### PR DESCRIPTION
Resolved #122. This issue is caused by an interaction between cobra and glog. We don't want to use glog going forward so we don't care about initializing it based on the command line.

Note: This means that logs that were previously visible will now be "hidden". glog was displaying them because they were "errors" even if they were logged with `Infof` (because it was logging before flag.Parse). The logged information will be made visible again as part of future work (i.e. https://github.com/GoogleCloudPlatform/terraform-validator/issues/255.)

To test this, build a binary based on main and try to convert this json:

```
{
  "format_version": "0.1",
  "terraform_version": "0.12.31",
  "resource_changes": [
    {
      "address": "google_container_registry.registry",
      "module_address": "",
      "mode": "managed",
      "type": "google_container_registry",
      "name": "registry",
      "provider_name": "google",
      "change": {
        "actions": [
          "create"
        ],
        "before": {
          "bucket_self_link": "https://www.googleapis.com/storage/v1/b/bucket_id",
          "id": "bucket_id",
          "location": null,
          "project": "my-project"
        },
        "after": {
          "bucket_self_link": "https://www.googleapis.com/storage/v1/b/bucket_id",
          "id": "bucket_id",
          "location": null,
          "project": "my-project"
        },
        "after_unknown": {}
      }
    }
  ]
}
```

Then do the same on this branch.