### PR TITLE
Removed references to forseti

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or as an audit of deployed resources. These constraints live in your
 organization's repository as the source of truth for your security and
 governance requirements. You can obtain constraints from the
 [Policy Library](./docs/policy_library.md), or
-[build your own constraint templates](https://github.com/forseti-security/policy-library/blob/master/docs/constraint_template_authoring.md).
+[build your own constraint templates](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/constraint_template_authoring.md).
 
 ## Table of Contents
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,9 +78,9 @@ func Execute() {
 
 var rootCmd = &cobra.Command{
 	Use:   "terraform-validator",
-	Short: "Validate terraform plans using Forseti Config Validator.",
-	Long: fmt.Sprintf(`Validate terraform plans by converting terraform resources to their Google CAI 
-(Cloud Asset Inventory) format and passing them through Forseti Config Validator.
+	Short: "Validate that a terraform plan conforms to Constraint Framework policies.",
+	Long: fmt.Sprintf(`Validate that a terraform plan conforms to a Constraint Framework 
+policy library written to expect Google CAI (Cloud Asset Inventory) data.
 
 Supported Terraform versions = 0.12+`),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -27,12 +27,13 @@ import (
 
 var validateCmd = &cobra.Command{
 	Use:   "validate <tfplan>",
-	Short: "Validate resources in a Terraform plan by calling Forseti Config Validator.",
-	Long: `Validate (terraform-validator validate) converts supported Terraform
-resources (see: "terraform-validate list-supported-resources") into their CAI
-(Cloud Asset Inventory) format and calls Forseti Config Validator,
-returning the violations. If any violations are reported an exit code of 2
-is set.
+	Short: "Validate that a terraform plan conforms to Constraint Framework policies.",
+	Long: `Validate that a terraform plan conforms to a Constraint Framework
+policy library written to expect Google CAI (Cloud Asset Inventory) data. 
+Unsupported terraform resources (see: "terraform-validate list-supported-resources")
+are skipped.
+
+Policy violations will result in an exit code of 2.
 
 Example:
   terraform-validator validate ./example/terraform.tfplan \

--- a/docs/contributing/add_new_resource.md
+++ b/docs/contributing/add_new_resource.md
@@ -2,15 +2,13 @@
 
 ## terraform-validator vs config-validator
 
-At its core, terraform-validator is a thin layer on top of [config-validator](https://github.com/forseti-security/config-validator), a shared library that takes in a [policy library](https://github.com/forseti-security/policy-library) and a set of [CAI assets](https://cloud.google.com/asset-inventory/docs/overview) and reports back any violations of the specified policies.
+At its core, terraform-validator is a thin layer on top of [config-validator](https://github.com/GoogleCloudPlatform/config-validator), a shared library that takes in a [policy library](https://github.com/GoogleCloudPlatform/policy-library) and a set of [CAI assets](https://cloud.google.com/asset-inventory/docs/overview) and reports back any violations of the specified policies.
 
 terraform-validator consumes a Terraform plan and uses it to build CAI Assets, which then get run through config-validator. These built Assets only exist locally, in memory.
 
-**Note**: Although policy-library is a repository inside of the forseti-security organization, Terraform Validator does _not_ require an active installation of Forseti. Terraform Validator is a self-contained binary. Policy libraries are a configuration mechanism shared by a number of tools via config-validator.
-
 ### Adding a new constraint template
 
-If an existing [bundle](https://github.com/forseti-security/policy-library/blob/master/docs/index.md#policy-bundles) (for example, [CIS v1.1](https://github.com/forseti-security/policy-library/blob/master/docs/bundles/cis-v1.1.md)) doesn't support a check you need, please consider contributing a [new constraint template](https://github.com/forseti-security/policy-library/blob/master/docs/constraint_template_authoring.md) to the policy-library repository.
+If an existing [bundle](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/index.md#policy-bundles) (for example, [CIS v1.1](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/bundles/cis-v1.1.md)) doesn't support a check you need, please consider contributing a [new constraint template](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/constraint_template_authoring.md) to the policy-library repository.
 
 ### Getting a terraform resource name from a GCP resource name
 
@@ -93,7 +91,7 @@ You can then run `make test` inside your terraform-google-conversion repository 
 
 Run `go get github.com/GoogleCloudPlatform/terraform-google-conversion` to update the version of terraform-google-conversion in use. (You can also use a [`replace` directive](https://golang.org/ref/mod#go-mod-file-replace) to use your local copy of the repository.)
 
-You can now build the binary (with `make build`) and test it. One way to do this would be to create a test project following the instructions in the [policy library user guide](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#for-local-development-environments) (but using the binary you just built.) It's easiest to use a [GCPAlwaysViolatesConstraintV1](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/testdata/sample_policies/always_violate/policies/constraints/always_violates.yaml) constraint for testing new resources; this is what the tests do. `terraform-validator convert tfplan.json` can show you what terraform-validator thinks the converted Asset looks like.
+You can now build the binary (with `make build`) and test it. One way to do this would be to create a test project following the instructions in the [policy library user guide](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/user_guide.md#for-local-development-environments) (but using the binary you just built.) It's easiest to use a [GCPAlwaysViolatesConstraintV1](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/testdata/sample_policies/always_violate/policies/constraints/always_violates.yaml) constraint for testing new resources; this is what the tests do. `terraform-validator convert tfplan.json` can show you what terraform-validator thinks the converted Asset looks like.
 
 Be sure to add test cases to [test/cli_test.go](https://github.com/GoogleCloudPlatform/terraform-validator/blob/c1295c541897e1357eb3e4d93a88d7083ff41c90/test/cli_test.go#L52) and [test/read_test.go](https://github.com/GoogleCloudPlatform/terraform-validator/blob/c1295c541897e1357eb3e4d93a88d7083ff41c90/test/read_test.go#L24). The test names refer to files in [testdata/templates](https://github.com/GoogleCloudPlatform/terraform-validator/tree/master/testdata/templates). You will generally need to add the following files:
    - A .tf file.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -12,7 +12,7 @@ If you want to contribute to Terraform Validator, check out the [contribution gu
 
 ## Example project
 
-The `example/` directory contains a basic Terraform config for testing the validator. Fully running the validator will require setting up a local [policy library](https://github.com/forseti-security/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library); however, this is not required to test conversion of terraform resources to CAI Assets.
+The `example/` directory contains a basic Terraform config for testing the validator. Fully running the validator will require setting up a local [policy library](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/user_guide.md#how-to-set-up-constraints-with-policy-library); however, this is not required to test conversion of terraform resources to CAI Assets.
 
 ```
 

--- a/docs/policy_library.md
+++ b/docs/policy_library.md
@@ -30,7 +30,7 @@ A Policy Library repository contains the following directories:
 
 ### 1. Duplicate Policy Library Repository
 
-Google provides a [sample repository](https://github.com/forseti-security/policy-library)
+Google provides a [sample repository](https://github.com/GoogleCloudPlatform/policy-library)
 with a set of pre-defined constraint templates. You can duplicate this repository
 into a private repository. First you should create a new **private** git repository.
 For example, if you use GitHub then you can use the [GitHub UI](https://github.com/new).
@@ -47,7 +47,7 @@ providers offer this feature as well.
 
 ```
 export GIT_REPO_ADDR="git@github.com:${YOUR_GITHUB_USERNAME}/policy-library.git"
-git clone --bare https://github.com/forseti-security/policy-library.git
+git clone --bare https://github.com/GoogleCloudPlatform/policy-library.git
 cd policy-library.git
 git push --mirror ${GIT_REPO_ADDR}
 cd ..
@@ -193,7 +193,7 @@ spec:
 
 ## Advanced usage
 
-If the existing constraint templates don't meet your needs, you can also [build your own constraint templates](https://github.com/forseti-security/policy-library/blob/master/docs/constraint_template_authoring.md).
+If the existing constraint templates don't meet your needs, you can also [build your own constraint templates](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/constraint_template_authoring.md).
 
 ## Periodic updates
 
@@ -201,7 +201,7 @@ Periodically you should pull any changes from the public repository, which might
 contain new templates and Rego files.
 
 ```
-git remote add public https://github.com/forseti-security/policy-library.git
+git remote add public https://github.com/GoogleCloudPlatform/policy-library.git
 git pull public master
 git push origin master
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -4,7 +4,7 @@ In this tutorial, you will apply a constraint that enforces IAM policy member
 domain restriction using [Cloud Shell](https://cloud.google.com/shell/).
 
 First click on this
-[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/forseti-security/policy-library.git)
+[link](https://console.cloud.google.com/cloudshell/open?cloudshell_image=gcr.io/graphite-cloud-shell-images/terraform:latest&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/policy-library.git)
 to open a new Cloud Shell session. The Cloud Shell session has Terraform
 pre-installed and the Policy Library repository cloned. Once you have the
 session open, the next step is to copy over the sample IAM domain restriction

--- a/tfgcv/doc.go
+++ b/tfgcv/doc.go
@@ -14,5 +14,5 @@
 
 // Package tfgcv pulls together the other packages in this project to take
 // a terraform plan, extract the planned resources in Google CAI format,
-// and run those CAI assets through the Forseti Config Validator.
+// and run those CAI assets through the Config Validator.
 package tfgcv


### PR DESCRIPTION
config-validator and policy-library are no longer housed within the forseti-security org. In order to reduce confusion, the documentation needs to be updated to not reference Forseti.