### PR TITLE
Made command definitions more modular

### DIFF
--- a/cmd/list_supported_resources.go
+++ b/cmd/list_supported_resources.go
@@ -21,16 +21,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var listSupportedResourcesCmd = &cobra.Command{
-	Use:   "list-supported-resources",
-	Short: "List supported terraform resources.",
-	RunE: func(c *cobra.Command, args []string) error {
-		list := converter.SupportedTerraformResources()
+type listSupportedResourcesOptions struct {}
 
-		for _, resource := range list {
-			fmt.Println(resource)
-		}
+func newListSupportedResourcesCmd() *cobra.Command {
+	o := listSupportedResourcesOptions{}
 
-		return nil
-	},
+	cmd := &cobra.Command{
+		Use:   "list-supported-resources",
+		Short: "List supported terraform resources.",
+		RunE: func(c *cobra.Command, args []string) error {
+			return o.run()
+		},
+	}
+	return cmd
+}
+
+func (o *listSupportedResourcesOptions) run() error {
+	list := converter.SupportedTerraformResources()
+
+	for _, resource := range list {
+		fmt.Println(resource)
+	}
+
+	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,11 +22,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display Terraform Validator version.",
-	RunE: func(c *cobra.Command, args []string) error {
-		fmt.Printf("Build version: %s\n", tfgcv.BuildVersion())
-		return nil
-	},
+type versionOptions struct {}
+
+func newVersionCmd() *cobra.Command {
+	o := versionOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Display Terraform Validator version.",
+		RunE: func(c *cobra.Command, args []string) error {
+			return o.run()
+		},
+	}
+
+	return cmd
+}
+
+func (o *versionOptions) run() error {
+	fmt.Printf("Build version: %s\n", tfgcv.BuildVersion())
+	return nil
 }


### PR DESCRIPTION
This is based loosely on the way that commands are defined in [hugo](https://github.com/gohugoio/hugo/blob/master/commands/gen.go), [helm](https://github.com/helm/helm/blob/a9c957d35b6a2ce9a8fab03d7cb72414e99c240c/cmd/helm/create.go), [dlv](https://github.com/derekparker/delve/blob/master/cmd/dlv/cmds/commands.go), and some other tools that use cobra. This allows us to group the commands with their options, and minimize the size of the command definition by splitting the implementation out into a separate function.

This is prep work for https://github.com/GoogleCloudPlatform/terraform-validator/issues/256; I wanted to refactor the way that these commands are defined prior to & separately from adding a new argument.