### PR TITLE
Ignore asset fetch with a warning if user does not have read permissions

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -254,6 +254,9 @@ func (c *Converter) addDelete(rc *tfjson.ResourceChange) error {
 				if errors.Cause(err) == converter.ErrEmptyIdentityField {
 					glog.Warningf("%s did not return a value for ID field. Skipping asset fetch.", key)
 					existingConverterAsset = nil
+				} else if errors.Cause(err) == converter.ErrLackingReadPermission {
+					glog.Warningf("Lacking read permissions for %s. Skipping asset fetch.", key)
+					existingConverterAsset = nil
 				} else if err != nil {
 					return errors.Wrap(err, "fetching asset")
 				} else {
@@ -304,6 +307,9 @@ func (c *Converter) addCreateOrUpdateOrNoop(rc *tfjson.ResourceChange) error {
 				asset, err := mapper.Fetch(&rd, c.cfg)
 				if errors.Cause(err) == converter.ErrEmptyIdentityField {
 					glog.Warningf("%s did not return a value for ID field. Skipping asset fetch.", key)
+					existingConverterAsset = nil
+				} else if errors.Cause(err) == converter.ErrLackingReadPermission {
+					glog.Warningf("Lacking read permissions for %s. Skipping asset fetch.", key)
 					existingConverterAsset = nil
 				} else if err != nil {
 					return errors.Wrap(err, "fetching asset")

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -254,9 +254,6 @@ func (c *Converter) addDelete(rc *tfjson.ResourceChange) error {
 				if errors.Cause(err) == converter.ErrEmptyIdentityField {
 					glog.Warningf("%s did not return a value for ID field. Skipping asset fetch.", key)
 					existingConverterAsset = nil
-				} else if errors.Cause(err) == converter.ErrLackingReadPermission {
-					glog.Warningf("Lacking read permissions for %s. Skipping asset fetch.", key)
-					existingConverterAsset = nil
 				} else if err != nil {
 					return errors.Wrap(err, "fetching asset")
 				} else {
@@ -307,9 +304,6 @@ func (c *Converter) addCreateOrUpdateOrNoop(rc *tfjson.ResourceChange) error {
 				asset, err := mapper.Fetch(&rd, c.cfg)
 				if errors.Cause(err) == converter.ErrEmptyIdentityField {
 					glog.Warningf("%s did not return a value for ID field. Skipping asset fetch.", key)
-					existingConverterAsset = nil
-				} else if errors.Cause(err) == converter.ErrLackingReadPermission {
-					glog.Warningf("Lacking read permissions for %s. Skipping asset fetch.", key)
 					existingConverterAsset = nil
 				} else if err != nil {
 					return errors.Wrap(err, "fetching asset")

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -37,6 +37,10 @@ GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.
 
 You can specify a [service account to impersonate](https://cloud.google.com/iam/docs/impersonating-service-accounts) for all Google API calls with the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable.
 
+### Validating compliance IAM member & binding resources
+
+Validating compliance for an IAM policy requires the full policy. However, the Terraform Provider's IAM member & binding resources only manage a slice of an IAM resource. In order to work around this, Terraform Validator fetches the full IAM resource from GCP and merges it with the Terraform resources prior to validation. This means that users who are validating IAM member and binding resources need to have permissions to read IAM policies - for example, via the Security Reviewer role.
+
 ## `terraform-validator validate`
 
 This command allows you to validate your terraform plan JSON against a specific policy library.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -37,9 +37,14 @@ GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.
 
 You can specify a [service account to impersonate](https://cloud.google.com/iam/docs/impersonating-service-accounts) for all Google API calls with the `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT` environment variable.
 
-### Validating compliance IAM member & binding resources
+### Required permissions
 
-Validating compliance for an IAM policy requires the full policy. However, the Terraform Provider's IAM member & binding resources only manage a slice of an IAM resource. In order to work around this, Terraform Validator fetches the full IAM resource from GCP and merges it with the Terraform resources prior to validation. This means that users who are validating IAM member and binding resources need to have permissions to read IAM policies - for example, via the Security Reviewer role.
+The GCP account being used for validation must have the following permissions:
+
+- **getIamPolicy permissions for any IAM members and bindings that are being validated.**
+  - Terraform Validator needs to get full IAM policies and merge them with members and bindings to get an accurate end state to validate.
+- **resourcemanager.projects.get for any projects that validated resources are related to.**
+  - Terraform Validator needs to get project ancestry from the API in order to accurately construct a full CAI Asset Name for validation.
 
 ## `terraform-validator validate`
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210628183505-f0289a8b1278
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210902210028-f286d71b9418
 	github.com/forseti-security/config-validator v0.0.0-20210621194145-08e4202b50d8
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,10 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v0.0.0-202105
 github.com/GoogleCloudPlatform/declarative-resource-client-library v0.0.0-20210519165700-76bc5cc4eeee/go.mod h1:oEeBHikdF/NrnUy0ornVaY1OT+jGvTqm+LQS0+ZDKzU=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210628183505-f0289a8b1278 h1:Qu1TGmdQRDgly4zL+2ucgc9JSzDoTmD3M5dmhdNHOPI=
 github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210628183505-f0289a8b1278/go.mod h1:G9nbobJVSUiZx3TTUnwk8d519lUtNR5UIoQweRUY3Rs=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210902183351-4366981879d6 h1:NnyYy/gBs5kYEiYSbouF8jekR6AtEV/ssIsdgeP8VBc=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210902183351-4366981879d6/go.mod h1:G9nbobJVSUiZx3TTUnwk8d519lUtNR5UIoQweRUY3Rs=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210902210028-f286d71b9418 h1:awIENM0MgxIdbVUKBAQrb3JQ6PCj7tpP4HyMwhEZRQE=
+github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210902210028-f286d71b9418/go.mod h1:G9nbobJVSUiZx3TTUnwk8d519lUtNR5UIoQweRUY3Rs=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=


### PR DESCRIPTION
Resolved #290. This can be tested manually but it's a bit tricky. You have to:

1. create a service account that doesn't have any permissions
2. Set up `GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=<that account>`
3. Generate a plan from a terraform file like:
   ```
   resource "google_project_iam_member" "viewer-a" {
     project = "my-project"
     role    = "roles/viewer"
     member  = "user:example-a@google.com"
   }
   ```
4. build terraform-validator and use it to convert the plan. You should get a warning due to lacking read permissions during "asset fetch", and then fail during getting resource ancestry (rather than failing due to lacking read permissions during asset fetch).

Unfortunately there's not currently a great way to add automated tests for this right now.