### PR TITLE
Piped zap loggers throughout the conversion process

### DIFF
--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -7,13 +7,15 @@ import (
 	"regexp"
 	"testing"
 
+	"go.uber.org/zap"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/option"
 )
 
 type testRetriever struct {
-	online bool
-	opts   []option.ClientOption
+	online      bool
+	opts        []option.ClientOption
+	errorLogger *zap.Logger
 }
 
 func (tr *testRetriever) NewResourceManagerClient(userAgent string) *cloudresourcemanager.Service {
@@ -94,13 +96,13 @@ func TestGetAncestry(t *testing.T) {
 
 	// option.WithEndpoint(ts.URL), option.WithoutAuthentication()
 	trOnline := &testRetriever{online: true, opts: []option.ClientOption{option.WithEndpoint(ts.URL), option.WithoutAuthentication()}}
-	amOnline, err := New(trOnline, ownerProject, ownerAncestry, "", false)
+	amOnline, err := New(trOnline, ownerProject, ownerAncestry, "", false, zap.NewExample())
 	if err != nil {
 		t.Fatalf("failed to create online ancestry manager: %s", err)
 	}
 
 	trOffline := &testRetriever{online: false}
-	amOffline, err := New(trOffline, ownerProject, ownerAncestry, "", true)
+	amOffline, err := New(trOffline, ownerProject, ownerAncestry, "", true, zap.NewExample())
 	if err != nil {
 		t.Fatalf("failed to create offline ancestry manager: %s", err)
 	}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -89,7 +89,7 @@ func (o *convertOptions) validateArgs(args []string) error {
 
 func (o *convertOptions) run(plan string) error {
 	ctx := context.Background()
-	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false)
+	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.errorLogger)
 	if err != nil {
 		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 			return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
-func MockReadPlannedAssets(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool) ([]google.Asset, error) {
+func MockReadPlannedAssets(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
 	return []google.Asset{
 		google.Asset{
 			Name: "//compute.googleapis.com/projects/my-project/zones/us-central1-a/disks/test-disk",

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -103,7 +103,7 @@ func (o *validateOptions) validateArgs(args []string) error {
 
 func (o *validateOptions) run(plan string) error {
 	ctx := context.Background()
-	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false)
+	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.errorLogger)
 	if err != nil {
 		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 			return errors.New("unable to parse provider project, please use --project flag")

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -25,6 +25,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 const testProject = "test-project"
@@ -39,11 +40,12 @@ func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing configuration")
 	}
-	ancestryManager, err := ancestrymanager.New(cfg, project, ancestry, ua, offline)
+	errorLogger := zap.NewExample()
+	ancestryManager, err := ancestrymanager.New(cfg, project, ancestry, ua, offline, errorLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource ancestryManager")
 	}
-	c := NewConverter(cfg, ancestryManager, offline, convertUnchanged)
+	c := NewConverter(cfg, ancestryManager, offline, convertUnchanged, errorLogger)
 	return c, nil
 }
 

--- a/converters/google/vendor_utils.go
+++ b/converters/google/vendor_utils.go
@@ -16,9 +16,9 @@ package google
 
 import (
 	"fmt"
-	"log"
 
 	converter "github.com/GoogleCloudPlatform/terraform-google-conversion/google"
+	"go.uber.org/zap"
 )
 
 // NOTE: These functions were pulled from github.com/terraform-providers/terraform-provider-google. They can go away when the functionality they are providing is implemented in the future github.com/GoogleCloudPlatform/terraform-converters package.
@@ -26,7 +26,8 @@ import (
 // getProject reads the "project" field from the given resource data and falls
 // back to the provider's value if not given. If the provider's value is not
 // given, an error is returned.
-func getProject(d converter.TerraformResourceData, config *converter.Config, cai converter.Asset) (string, error) {
+func getProject(d converter.TerraformResourceData, config *converter.Config, cai converter.Asset, errorLogger *zap.Logger) (string, error) {
+
 	switch cai.Type {
 	case "cloudresourcemanager.googleapis.com/Project",
 		"cloudbilling.googleapis.com/ProjectBillingInfo":
@@ -39,7 +40,7 @@ func getProject(d converter.TerraformResourceData, config *converter.Config, cai
 		if ok {
 			return res.(string), nil
 		} else {
-			log.Printf("[WARN] Failed to retrieve project_id for %s from resource", cai.Name)
+			errorLogger.Warn(fmt.Sprintf("Failed to retrieve project_id for %s from resource", cai.Name))
 		}
 	case "storage.googleapis.com/Bucket":
 		if cai.Resource != nil {
@@ -48,7 +49,7 @@ func getProject(d converter.TerraformResourceData, config *converter.Config, cai
 				return res.(string), nil
 			}
 		}
-		log.Printf("[WARN] Failed to retrieve project_id for %s from cai resource", cai.Name)
+		errorLogger.Warn(fmt.Sprintf("Failed to retrieve project_id for %s from cai resource", cai.Name))
 	}
 
 	return getProjectFromSchema("project", d, config)

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
+	"go.uber.org/zap"
 )
 
 func TestReadPlannedAssetsCoverage(t *testing.T) {
@@ -92,7 +93,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")
 			ctx := context.Background()
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false)
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false, zap.NewExample())
 			if err != nil {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
 			}

--- a/tfgcv/planned_assets_test.go
+++ b/tfgcv/planned_assets_test.go
@@ -2,6 +2,7 @@ package tfgcv
 
 import (
 	"context"
+	"go.uber.org/zap"
 	"path/filepath"
 	"testing"
 )
@@ -76,7 +77,7 @@ func TestReadPlannedAssets(t *testing.T) {
 			var offline bool
 			offline = true
 			ctx := context.Background()
-			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, tt.args.ancestry, offline, tt.args.convertUnchanged)
+			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, tt.args.ancestry, offline, tt.args.convertUnchanged, zap.NewExample())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReadPlannedAssets() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
With this change, all of our error / status logging should use the same zap logger, allowing us to enable structured logging for everything. This is a follow-up for https://github.com/GoogleCloudPlatform/terraform-validator/pull/304