### PR TITLE
Cleaned up add new resource docs to better reflect the actual desired process

### DIFF
--- a/docs/contributing/add_new_resource.md
+++ b/docs/contributing/add_new_resource.md
@@ -21,7 +21,7 @@ A resource is "supported" by terraform-validator if it has an entry in [mappers.
 Adding support for a resource has four steps:
 
 1. Make changes to [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules) to add any necessary code to terraform-google-conversion.
-2. Make changes to terraform-validator to adds tests for the new resource. Make sure the new tests pass locally.
+2. Add tests for the new resource to terraform-validator, and run them against a [locally-generated](https://github.com/GoogleCloudPlatform/magic-modules/#generating-terraform-google-conversion) copy of terraform-google-conversion.
 3. Make PRs for Magic Modules & terraform-validator with your changes. The reviewer will double-check that your code works and then merge the Magic Modules PR.
 4. Once the Magic Modules PR is merged, it will automatically update terraform-google-conversion with your changes. Update your terraform-validator PR to use the new version of terraform-google.conversion.
 
@@ -89,9 +89,9 @@ make validator OUTPUT_PATH="/path/to/your/terraform-google-conversion"
 
 You can then run `make test` inside your terraform-google-conversion repository to make sure those tests pass.
 
-### 2. Terraform Validator
+### 2. Terraform Validator tests
 
-Now that you have a local copy of terraform-google-conversion that has been generated from Magic Modules, you need to make Terraform Validator use it for local testing. You can do this with a [`replace` directive](https://golang.org/ref/mod#go-mod-file-replace):
+Now that you have a local copy of terraform-google-conversion that has been [generated from Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules/#generating-terraform-google-conversion), you need to make Terraform Validator use it for local testing. You can do this with a [`replace` directive](https://golang.org/ref/mod#go-mod-file-replace):
 
 ```
 replace github.com/GoogleCloudPlatform/terraform-google-conversion => /path/to/your/terraform-google-conversion
@@ -114,14 +114,14 @@ Now that you have your code working locally, open PRs for [Magic Modules](https:
 
 For the Magic Modules PR, the most important check is `terraform-google-conversion-test` - as long as that's passing, you're probably fine. If it is failing, go back to step 1 and try running `make test` for terraform-google-conversion to reproduce & fix the failure.
 
-For terraform-validator, the tests will not pass at this point, because the terraform-google-conversion dependency has not yet been updated. As long as the tests are passing locally for you, it should be fine.
+For terraform-validator, the CI tests will not pass at this point, because the terraform-google-conversion dependency has not yet been updated. As long as the tests are passing locally for you, it should be fine.
 
 ### 4. Update terraform-google-conversion dependency
 
-In your terraform-validator PR, update the terraform-google-conversion dependency. This command will make the necessary changes:
+After the Magic Modules PR is merged, and the terraform-google-conversion repository contains your changes, update the terraform-google-conversion dependency in your terraform-validator PR. This command will make the necessary changes:
 
 ```bash
 go get github.com/GoogleCloudPlatform/terraform-google-conversion
 ```
 
-If tf-validator-build is failing after you make this change, double-check that you're able to run `make test` locally inside the terraform-validator repository.
+If the CI tests are still failing after you make this change, double-check that you're able to run `make test` locally inside the terraform-validator repository using the updated (not replaced) dependency.

--- a/docs/contributing/add_new_resource.md
+++ b/docs/contributing/add_new_resource.md
@@ -18,10 +18,12 @@ The first step in determining if a GCP resource is supported is to figure out th
 
 A resource is "supported" by terraform-validator if it has an entry in [mappers.go](https://github.com/GoogleCloudPlatform/terraform-google-conversion/blob/master/google/mappers.go). For example, you could search mappers.go for [`google_compute_disk`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) to see if that resource is supported.
 
-Adding support for a resource has two steps:
+Adding support for a resource has four steps:
 
-1. Make a PR for [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules) to add the necessary code to terraform-google-conversion. Once your PR is merged, the code will be automatically copied into terraform-google-conversion.
-2. Make a PR for terraform-validator that updates the version of terraform-google-conversion and adds tests for the new resource.
+1. Make changes to [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules) to add any necessary code to terraform-google-conversion.
+2. Make changes to terraform-validator to adds tests for the new resource. Make sure the new tests pass locally.
+3. Make PRs for Magic Modules & terraform-validator with your changes. The reviewer will double-check that your code works and then merge the Magic Modules PR.
+4. Once the Magic Modules PR is merged, it will automatically update terraform-google-conversion with your changes. Update your terraform-validator PR to use the new version of terraform-google.conversion.
 
 Each of these is discussed in more detail below.
 
@@ -85,11 +87,15 @@ To generate terraform-google-conversion code locally, run the following from the
 make validator OUTPUT_PATH="/path/to/your/terraform-google-conversion"
 ```
 
-You can then run `make test` inside your terraform-google-conversion repository to make sure the tests pass prior to creating your PR.
+You can then run `make test` inside your terraform-google-conversion repository to make sure those tests pass.
 
 ### 2. Terraform Validator
 
-Run `go get github.com/GoogleCloudPlatform/terraform-google-conversion` to update the version of terraform-google-conversion in use. (You can also use a [`replace` directive](https://golang.org/ref/mod#go-mod-file-replace) to use your local copy of the repository.)
+Now that you have a local copy of terraform-google-conversion that has been generated from Magic Modules, you need to make Terraform Validator use it for local testing. You can do this with a [`replace` directive](https://golang.org/ref/mod#go-mod-file-replace):
+
+```
+replace github.com/GoogleCloudPlatform/terraform-google-conversion => /path/to/your/terraform-google-conversion
+```
 
 You can now build the binary (with `make build`) and test it. One way to do this would be to create a test project following the instructions in the [policy library user guide](https://github.com/GoogleCloudPlatform/policy-library/blob/master/docs/user_guide.md#for-local-development-environments) (but using the binary you just built.) It's easiest to use a [GCPAlwaysViolatesConstraintV1](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/testdata/sample_policies/always_violate/policies/constraints/always_violates.yaml) constraint for testing new resources; this is what the tests do. `terraform-validator convert tfplan.json` can show you what terraform-validator thinks the converted Asset looks like.
 
@@ -99,3 +105,23 @@ Be sure to add test cases to [test/cli_test.go](https://github.com/GoogleCloudPl
    - A .json file (representing the output of `terraform-validator convert`)
 
 See [Getting started](./getting_started.md) for details on running tests.
+
+Try to get your tests passing locally before proceeding. (But you can also go ahead and open PRs if you're running into issues you can't figure out how to resolve.)
+
+### 3. Make PRs
+
+Now that you have your code working locally, open PRs for [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules) and terraform-validator. The reviewer will make sure your code works as expected.
+
+For the Magic Modules PR, the most important check is `terraform-google-conversion-test` - as long as that's passing, you're probably fine. If it is failing, go back to step 1 and try running `make test` for terraform-google-conversion to reproduce & fix the failure.
+
+For terraform-validator, the tests will not pass at this point, because the terraform-google-conversion dependency has not yet been updated. As long as the tests are passing locally for you, it should be fine.
+
+### 4. Update terraform-google-conversion dependency
+
+In your terraform-validator PR, update the terraform-google-conversion dependency. This command will make the necessary changes:
+
+```bash
+go get github.com/GoogleCloudPlatform/terraform-google-conversion
+```
+
+If tf-validator-build is failing after you make this change, double-check that you're able to run `make test` locally inside the terraform-validator repository.


### PR DESCRIPTION
Currently the docs guide users to make a full MM PR prior to starting their terraform-validator PR. However, we actually want to guide users to do full testing of their code prior to opening their first PR. This should help make the PR review process faster & set appropriate expectations.