### PR TITLE
Add tests for google_access_context_manager_service_perimeter resource.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
-	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210917180804-7d769d84f6a1
+	github.com/GoogleCloudPlatform/terraform-google-conversion v0.0.0-20210922165347-a9a95ede440e
 	github.com/forseti-security/config-validator v0.0.0-20210621194145-08e4202b50d8
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -59,6 +59,7 @@ func TestCLI(t *testing.T) {
 		{name: "firewall"},
 		{name: "instance"},
 		{name: "sql"},
+		{name: "example_access_context_manager_service_perimeter"},
 		{name: "example_bigquery_dataset"},
 		{name: "example_bigtable_instance"},
 		{name: "example_compute_disk"},

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -20,7 +20,7 @@ const (
 	defaultOrganization    = "12345"
 	defaultFolder          = "67890"
 	defaultProject         = "foobar"
-	defaultProviderVersion = "3.51.0"
+	defaultProviderVersion = "3.84.0"
 )
 
 var (

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -20,6 +20,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 	cases := []struct {
 		name string
 	}{
+		{name: "example_access_context_manager_service_perimeter"},
 		{name: "example_bigquery_dataset"},
 		{name: "example_bigtable_instance"},
 		{name: "example_compute_disk"},

--- a/testdata/templates/example_access_context_manager_service_perimeter.json
+++ b/testdata/templates/example_access_context_manager_service_perimeter.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "//accesscontextmanager.googleapis.com/accessPolicies/987654/servicePerimeters/restrict_storage",
+    "asset_type": "accesscontextmanager.googleapis.com/ServicePerimeter",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/accesscontextmanager/v1/rest",
+      "discovery_name": "ServicePerimeter",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "name": "accessPolicies/987654/servicePerimeters/restrict_storage",
+        "perimeterType": "PERIMETER_TYPE_REGULAR",
+        "status": {
+          "egressPolicies": [
+            {
+              "egressFrom": {
+                "identityType": "ANY_USER_ACCOUNT"
+              }
+            }
+          ],
+          "ingressPolicies": [
+            {
+              "ingressFrom": {
+                "identityType": "ANY_IDENTITY",
+                "sources": [
+                  {
+                    "accessLevel": "accessPolicies/987654/accessLevels/restrict_storage"
+                  }
+                ]
+              },
+              "ingressTo": {
+                "operations": [
+                  {
+                    "methodSelectors": [
+                      {
+                        "method": "google.storage.objects.create"
+                      }
+                    ],
+                    "serviceName": "storage.googleapis.com"
+                  }
+                ],
+                "resources": [
+                  "*"
+                ]
+              }
+            }
+          ],
+          "resources": [
+            "projects/54321",
+            "projects/4321"
+          ],
+          "restrictedServices": [
+            "bigquery.googleapis.com",
+            "storage.googleapis.com"
+          ]
+        },
+        "title": "restrict_storage"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_access_context_manager_service_perimeter.tf
+++ b/testdata/templates/example_access_context_manager_service_perimeter.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_access_context_manager_service_perimeter" "service-perimeter" {
+  parent = "accessPolicies/987654"
+  name   = "accessPolicies/987654/servicePerimeters/restrict_storage"
+  title  = "restrict_storage"
+
+  status {
+    restricted_services = ["storage.googleapis.com", "bigquery.googleapis.com"]
+    resources = ["projects/54321", "projects/4321"]
+
+    ingress_policies {
+      ingress_from {
+        sources {
+          access_level = "accessPolicies/987654/accessLevels/restrict_storage"
+        }
+        identity_type = "ANY_IDENTITY"
+      }
+
+      ingress_to {
+        resources = ["*"]
+        operations {
+          service_name = "storage.googleapis.com"
+          method_selectors {
+            method = "google.storage.objects.create"
+          }
+        }
+      }
+    }
+
+    egress_policies {
+      egress_from {
+        identity_type = "ANY_USER_ACCOUNT"
+      }
+    }
+  }
+}

--- a/testdata/templates/example_access_context_manager_service_perimeter.tfplan.json
+++ b/testdata/templates/example_access_context_manager_service_perimeter.tfplan.json
@@ -1,0 +1,324 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.6",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_access_context_manager_service_perimeter.service-perimeter",
+          "mode": "managed",
+          "type": "google_access_context_manager_service_perimeter",
+          "name": "service-perimeter",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "name": "accessPolicies/987654/servicePerimeters/restrict_storage",
+            "parent": "accessPolicies/987654",
+            "perimeter_type": "PERIMETER_TYPE_REGULAR",
+            "spec": [],
+            "status": [
+              {
+                "access_levels": null,
+                "egress_policies": [
+                  {
+                    "egress_from": [
+                      {
+                        "identities": null,
+                        "identity_type": "ANY_USER_ACCOUNT"
+                      }
+                    ],
+                    "egress_to": []
+                  }
+                ],
+                "ingress_policies": [
+                  {
+                    "ingress_from": [
+                      {
+                        "identities": null,
+                        "identity_type": "ANY_IDENTITY",
+                        "sources": [
+                          {
+                            "access_level": "accessPolicies/987654/accessLevels/restrict_storage",
+                            "resource": null
+                          }
+                        ]
+                      }
+                    ],
+                    "ingress_to": [
+                      {
+                        "operations": [
+                          {
+                            "method_selectors": [
+                              {
+                                "method": "google.storage.objects.create",
+                                "permission": null
+                              }
+                            ],
+                            "service_name": "storage.googleapis.com"
+                          }
+                        ],
+                        "resources": [
+                          "*"
+                        ]
+                      }
+                    ]
+                  }
+                ],
+                "resources": [
+                  "projects/54321",
+                  "projects/4321"
+                ],
+                "restricted_services": [
+                  "storage.googleapis.com",
+                  "bigquery.googleapis.com"
+                ],
+                "vpc_accessible_services": []
+              }
+            ],
+            "timeouts": null,
+            "title": "restrict_storage",
+            "use_explicit_dry_run_spec": null
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_access_context_manager_service_perimeter.service-perimeter",
+      "mode": "managed",
+      "type": "google_access_context_manager_service_perimeter",
+      "name": "service-perimeter",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "name": "accessPolicies/987654/servicePerimeters/restrict_storage",
+          "parent": "accessPolicies/987654",
+          "perimeter_type": "PERIMETER_TYPE_REGULAR",
+          "spec": [],
+          "status": [
+            {
+              "access_levels": null,
+              "egress_policies": [
+                {
+                  "egress_from": [
+                    {
+                      "identities": null,
+                      "identity_type": "ANY_USER_ACCOUNT"
+                    }
+                  ],
+                  "egress_to": []
+                }
+              ],
+              "ingress_policies": [
+                {
+                  "ingress_from": [
+                    {
+                      "identities": null,
+                      "identity_type": "ANY_IDENTITY",
+                      "sources": [
+                        {
+                          "access_level": "accessPolicies/987654/accessLevels/restrict_storage",
+                          "resource": null
+                        }
+                      ]
+                    }
+                  ],
+                  "ingress_to": [
+                    {
+                      "operations": [
+                        {
+                          "method_selectors": [
+                            {
+                              "method": "google.storage.objects.create",
+                              "permission": null
+                            }
+                          ],
+                          "service_name": "storage.googleapis.com"
+                        }
+                      ],
+                      "resources": [
+                        "*"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "resources": [
+                "projects/54321",
+                "projects/4321"
+              ],
+              "restricted_services": [
+                "bigquery.googleapis.com",
+                "storage.googleapis.com"
+              ],
+              "vpc_accessible_services": []
+            }
+          ],
+          "timeouts": null,
+          "title": "restrict_storage",
+          "use_explicit_dry_run_spec": null
+        },
+        "after_unknown": {
+          "create_time": true,
+          "id": true,
+          "spec": [],
+          "status": [
+            {
+              "egress_policies": [
+                {
+                  "egress_from": [
+                    {}
+                  ],
+                  "egress_to": []
+                }
+              ],
+              "ingress_policies": [
+                {
+                  "ingress_from": [
+                    {
+                      "sources": [
+                        {}
+                      ]
+                    }
+                  ],
+                  "ingress_to": [
+                    {
+                      "operations": [
+                        {
+                          "method_selectors": [
+                            {}
+                          ]
+                        }
+                      ],
+                      "resources": [
+                        false
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "resources": [
+                false
+              ],
+              "restricted_services": [
+                false
+              ],
+              "vpc_accessible_services": []
+            }
+          ],
+          "update_time": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": "{{.Provider.project}}"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_access_context_manager_service_perimeter.service-perimeter",
+          "mode": "managed",
+          "type": "google_access_context_manager_service_perimeter",
+          "name": "service-perimeter",
+          "provider_config_key": "google",
+          "expressions": {
+            "name": {
+              "constant_value": "accessPolicies/987654/servicePerimeters/restrict_storage"
+            },
+            "parent": {
+              "constant_value": "accessPolicies/987654"
+            },
+            "status": [
+              {
+                "egress_policies": [
+                  {
+                    "egress_from": [
+                      {
+                        "identity_type": {
+                          "constant_value": "ANY_USER_ACCOUNT"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "ingress_policies": [
+                  {
+                    "ingress_from": [
+                      {
+                        "identity_type": {
+                          "constant_value": "ANY_IDENTITY"
+                        },
+                        "sources": [
+                          {
+                            "access_level": {
+                              "constant_value": "accessPolicies/987654/accessLevels/restrict_storage"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "ingress_to": [
+                      {
+                        "operations": [
+                          {
+                            "method_selectors": [
+                              {
+                                "method": {
+                                  "constant_value": "google.storage.objects.create"
+                                }
+                              }
+                            ],
+                            "service_name": {
+                              "constant_value": "storage.googleapis.com"
+                            }
+                          }
+                        ],
+                        "resources": {
+                          "constant_value": [
+                            "*"
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "resources": {
+                  "constant_value": [
+                    "projects/54321",
+                    "projects/4321"
+                  ]
+                },
+                "restricted_services": {
+                  "constant_value": [
+                    "bigquery.googleapis.com",
+                    "storage.googleapis.com"
+                  ]
+                }
+              }
+            ],
+            "title": {
+              "constant_value": "restrict_storage"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/terraform-validator/issues/309#issue-1004492601

- Added tests for new resource google_access_context_manager_service_perimeter.
- Updated terraform-google-conversion version.
- Updated default terraform google provider version used in tests.