### PR TITLE
Removed "level" field from error logger

### DIFF
--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 )
 
-
 func testAssets() []google.Asset {
 	return []google.Asset{
 		google.Asset{
@@ -34,7 +33,6 @@ func testAssets() []google.Asset {
 		},
 	}
 }
-
 
 func MockReadPlannedAssets(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
 	return testAssets(), nil

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"os"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
@@ -68,7 +66,7 @@ func newConsoleEncoder(cfg zapcore.EncoderConfig) errorEncoder {
 	}
 }
 
-func newErrorLogger(verbose, useStructuredLogging bool) *zap.Logger {
+func newErrorLogger(verbose, useStructuredLogging bool, writeSyncer zapcore.WriteSyncer) *zap.Logger {
 	// Return a logger that produces expected structured output format for errors
 	var level zap.AtomicLevel
 	options := []zap.Option{
@@ -100,11 +98,11 @@ func newErrorLogger(verbose, useStructuredLogging bool) *zap.Logger {
 	} else {
 		encoder = newConsoleEncoder(encoderConfig)
 	}
-	core := zapcore.NewCore(encoder, zapcore.Lock(os.Stderr), level)
+	core := zapcore.NewCore(encoder, writeSyncer, level)
 	return zap.New(core, options...)
 }
 
-func newOutputLogger() *zap.Logger {
+func newOutputLogger(writeSyncer zapcore.WriteSyncer) *zap.Logger {
 	// Return a logger that produces expected structured output format for output
 	options := []zap.Option{
 		zap.Fields(
@@ -125,6 +123,6 @@ func newOutputLogger() *zap.Logger {
 		EncodeTime:    zapcore.RFC3339NanoTimeEncoder,
 	}
 	encoder := zapcore.NewJSONEncoder(encoderConfig)
-	core := zapcore.NewCore(encoder, zapcore.Lock(os.Stdout), level)
+	core := zapcore.NewCore(encoder, writeSyncer, level)
 	return zap.New(core, options...)
 }

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -86,7 +86,7 @@ func newErrorLogger(verbose, useStructuredLogging bool, writeSyncer zapcore.Writ
 
 	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:       "timestamp",
-		LevelKey:      "level",
+		LevelKey:      "",
 		MessageKey:    "",
 		StacktraceKey: "",
 		EncodeLevel:   zapcore.LowercaseLevelEncoder,

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -18,7 +18,6 @@ func (bws bufferWriteSyncer) Sync() error {
 	return nil
 }
 
-
 func newTestErrorLogger(verbose, useStructuredLogging bool) (*zap.Logger, *bytes.Buffer) {
 	buf := new(bytes.Buffer)
 	syncer := bufferWriteSyncer{Buffer: buf}
@@ -55,10 +54,10 @@ func TestErrorLoggerSchema(t *testing.T) {
 	json.Unmarshal(outputJSON, &output)
 
 	expectedOutput := map[string]interface{}{
-		"version": "v1.0.0",
+		"version":   "v1.0.0",
 		"timestamp": "tested separately",
 		"error_details": map[string]interface{}{
-			"error": "This is a message",
+			"error":   "This is a message",
 			"context": "",
 		},
 	}

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -1,27 +1,79 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
-func newTestErrorLogger(verbose, useStructuredLogging bool) (*zap.Logger, *observer.ObservedLogs) {
-	logger := newErrorLogger(verbose, useStructuredLogging)
-	observerCore, logs := observer.New(zap.DebugLevel)
-	wrapper := zap.WrapCore(func(zapcore.Core) zapcore.Core {
-		return observerCore
-	})
-
-	return logger.WithOptions(wrapper), logs
+type bufferWriteSyncer struct {
+	*bytes.Buffer
 }
 
-func newTestOutputLogger() (*zap.Logger, *observer.ObservedLogs) {
-	logger := newOutputLogger()
-	observerCore, logs := observer.New(zap.DebugLevel)
-	wrapper := zap.WrapCore(func(zapcore.Core) zapcore.Core {
-		return observerCore
-	})
+func (bws bufferWriteSyncer) Sync() error {
+	return nil
+}
 
-	return logger.WithOptions(wrapper), logs
+
+func newTestErrorLogger(verbose, useStructuredLogging bool) (*zap.Logger, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	syncer := bufferWriteSyncer{Buffer: buf}
+	logger := newErrorLogger(verbose, useStructuredLogging, syncer)
+	return logger, syncer.Buffer
+}
+
+func newTestOutputLogger() (*zap.Logger, *bytes.Buffer) {
+	buf := new(bytes.Buffer)
+	syncer := bufferWriteSyncer{Buffer: buf}
+	logger := newOutputLogger(syncer)
+	return logger, syncer.Buffer
+}
+
+func TestErrorLoggerSchema(t *testing.T) {
+	// Expected schema is:
+	// {
+	//     "version": "vX.X.X",
+	//     "timestamp": "RFC 3339-encoded timestamp",
+	//     "error_details": {
+	//         "error": "error type",
+	//         "context": "additional error context (optional)"
+	//     }
+	// }
+	verbose := true
+	useStructuredLogging := true
+
+	errorLogger, buf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger.Info("This is a message")
+
+	outputJSON := buf.Bytes()
+
+	var output map[string]interface{}
+	json.Unmarshal(outputJSON, &output)
+
+	expectedOutput := map[string]interface{}{
+		"version": "v1.0.0",
+		"timestamp": "tested separately",
+		"error_details": map[string]interface{}{
+			"error": "This is a message",
+			"context": "",
+		},
+	}
+
+	a := assert.New(t)
+	a.Equal(len(output), len(expectedOutput))
+
+	for k := range expectedOutput {
+		a.Contains(output, k)
+	}
+
+	a.Equal(output["version"], expectedOutput["version"])
+	a.Equal(output["error_details"], expectedOutput["error_details"])
+
+	// This should not fail
+	_, err := time.Parse(time.RFC3339Nano, output["timestamp"].(string))
+	a.Nil(err)
 }

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -76,3 +76,47 @@ func TestErrorLoggerSchema(t *testing.T) {
 	_, err := time.Parse(time.RFC3339Nano, output["timestamp"].(string))
 	a.Nil(err)
 }
+
+func TestOutputLoggerSchema(t *testing.T) {
+	// Expected schema is:
+	// {
+	//     "version": "vX.X.X",
+	//     "timestamp": "RFC 3339-encoded timestamp",
+	//     "body": "Message content",  // Optional
+	//     "resource_body": {},  // Optional, {} or []
+	// }
+
+	resourceBody := []interface{}{"foo", "bar", "baz"}
+	outputLogger, buf := newTestOutputLogger()
+	outputLogger.Info(
+		"This is a message",
+		zap.Any("resource_body", resourceBody),
+	)
+
+	outputJSON := buf.Bytes()
+
+	var output map[string]interface{}
+	json.Unmarshal(outputJSON, &output)
+
+	expectedOutput := map[string]interface{}{
+		"version":       "v1.0.0",
+		"timestamp":     "tested separately",
+		"body":          "This is a message",
+		"resource_body": resourceBody,
+	}
+
+	a := assert.New(t)
+	a.Equal(len(output), len(expectedOutput))
+
+	for k := range expectedOutput {
+		a.Contains(output, k)
+	}
+
+	a.Equal(output["version"], expectedOutput["version"])
+	a.Equal(output["body"], expectedOutput["body"])
+	a.Equal(output["resource_body"], expectedOutput["resource_body"])
+
+	// This should not fail
+	_, err := time.Parse(time.RFC3339Nano, output["timestamp"].(string))
+	a.Nil(err)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const rootCmdDesc = `
@@ -48,12 +49,12 @@ func newRootCmd() (*cobra.Command, *zap.Logger, error) {
 	cmd.PersistentFlags().BoolVar(&o.verbose, "verbose", false, "Log additional output")
 
 	useStructuredLogging := os.Getenv("USE_STRUCTURED_LOGGING") == "true"
-	errorLogger := newErrorLogger(o.verbose, useStructuredLogging)
+	errorLogger := newErrorLogger(o.verbose, useStructuredLogging, zapcore.Lock(os.Stderr))
 	defer errorLogger.Sync()
 	zap.RedirectStdLog(errorLogger)
 	o.errorLogger = errorLogger
 
-	outputLogger := newOutputLogger()
+	outputLogger := newOutputLogger(zapcore.Lock(os.Stdout))
 	defer outputLogger.Sync()
 
 	cmd.AddCommand(newConvertCmd(errorLogger, outputLogger, useStructuredLogging))


### PR DESCRIPTION
In order to adhere more strictly to the error message format described in #255, we need to not include "level" field in error logging. Since the stable "API" we're defining is the JSON output, I've rewritten the tests against JSON output instead of zap internals; the zap internals don't necessarily give you enough information to know what the JSON output will look like, and I think we're not (currently) testing log output to the extent where it would be useful to have separate test methodology for basic formatting vs. more complex output.

(Also it turns out that a.Equal puts the `expected` value first, so I fixed that for the tests I was touching anyway.)