### PR TITLE
Switched to verbosity flag

### DIFF
--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -40,18 +40,22 @@ func MockReadPlannedAssets(ctx context.Context, path, project, ancestry string, 
 
 func TestConvertRun(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := true
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := convertOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
+	}
+	o := convertOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
 	}
 
 	err := o.run("/path/to/plan")
@@ -77,18 +81,22 @@ func TestConvertRun(t *testing.T) {
 
 func TestConvertRunLegacy(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := false
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := convertOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
+	}
+	o := convertOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
 	}
 
 	err := o.run("/path/to/plan")

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -18,10 +18,10 @@ func (bws bufferWriteSyncer) Sync() error {
 	return nil
 }
 
-func newTestErrorLogger(verbose, useStructuredLogging bool) (*zap.Logger, *bytes.Buffer) {
+func newTestErrorLogger(verbosity string, useStructuredLogging bool) (*zap.Logger, *bytes.Buffer) {
 	buf := new(bytes.Buffer)
 	syncer := bufferWriteSyncer{Buffer: buf}
-	logger := newErrorLogger(verbose, useStructuredLogging, syncer)
+	logger := newErrorLogger(verbosity, useStructuredLogging, syncer)
 	return logger, syncer.Buffer
 }
 
@@ -42,10 +42,10 @@ func TestErrorLoggerSchema(t *testing.T) {
 	//         "context": "additional error context (optional)"
 	//     }
 	// }
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := true
 
-	errorLogger, buf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, buf := newTestErrorLogger(verbosity, useStructuredLogging)
 	errorLogger.Info("This is a message")
 
 	outputJSON := buf.Bytes()

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -39,22 +39,26 @@ func MockValidateAssetsWithViolations(ctx context.Context, assets []google.Asset
 
 func TestValidateRun(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := true
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := validateOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
-		policyPath:           "",
-		outputJSON:           false,
-		dryRun:               false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
-		validateAssets:       MockValidateAssetsWithViolations,
+	}
+	o := validateOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		policyPath:        "",
+		outputJSON:        false,
+		dryRun:            false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
+		validateAssets:    MockValidateAssetsWithViolations,
 	}
 
 	err := o.run("/path/to/plan")
@@ -80,22 +84,26 @@ func TestValidateRun(t *testing.T) {
 
 func TestValidateRunNoViolations(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := true
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := validateOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
-		policyPath:           "",
-		outputJSON:           false,
-		dryRun:               false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
-		validateAssets:       MockValidateAssetsNoViolations,
+	}
+	o := validateOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		policyPath:        "",
+		outputJSON:        false,
+		dryRun:            false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
+		validateAssets:    MockValidateAssetsNoViolations,
 	}
 
 	err := o.run("/path/to/plan")
@@ -116,22 +124,26 @@ func TestValidateRunNoViolations(t *testing.T) {
 
 func TestValidateRunLegacy(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := false
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := validateOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
-		policyPath:           "",
-		outputJSON:           false,
-		dryRun:               false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
-		validateAssets:       MockValidateAssetsWithViolations,
+	}
+	o := validateOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		policyPath:        "",
+		outputJSON:        false,
+		dryRun:            false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
+		validateAssets:    MockValidateAssetsWithViolations,
 	}
 
 	err := o.run("/path/to/plan")
@@ -147,22 +159,26 @@ func TestValidateRunLegacy(t *testing.T) {
 
 func TestValidateRunNoViolationsLegacy(t *testing.T) {
 	a := assert.New(t)
-	verbose := true
+	verbosity := "debug"
 	useStructuredLogging := false
-	errorLogger, errorBuf := newTestErrorLogger(verbose, useStructuredLogging)
+	errorLogger, errorBuf := newTestErrorLogger(verbosity, useStructuredLogging)
 	outputLogger, outputBuf := newTestOutputLogger()
-	o := validateOptions{
-		project:              "",
-		ancestry:             "",
-		offline:              false,
-		policyPath:           "",
-		outputJSON:           false,
-		dryRun:               false,
+	ro := &rootOptions{
+		verbosity:            verbosity,
+		useStructuredLogging: useStructuredLogging,
 		errorLogger:          errorLogger,
 		outputLogger:         outputLogger,
-		useStructuredLogging: useStructuredLogging,
-		readPlannedAssets:    MockReadPlannedAssets,
-		validateAssets:       MockValidateAssetsNoViolations,
+	}
+	o := validateOptions{
+		project:           "",
+		ancestry:          "",
+		offline:           false,
+		policyPath:        "",
+		outputJSON:        false,
+		dryRun:            false,
+		rootOptions:       ro,
+		readPlannedAssets: MockReadPlannedAssets,
+		validateAssets:    MockValidateAssetsNoViolations,
 	}
 
 	err := o.run("/path/to/plan")


### PR DESCRIPTION
This replaces the boolean --verbose flag. Also, it turns out that the flag values actually get extracted from the command line during the Execute step, so the value of `--verbose` wasn't actually being used to initialize the loggers. I moved the logger initialization into PersistentPreRun to resolve this issue, since that [runs first](https://github.com/spf13/cobra/blob/4fd30b69ee2b62cf3bbecf0a423f8a1ee47f5f24/command.go#L98).

Note: About 1/3 of this PR is whitespace changes - reviewing with whitespace changes hidden might be easier.