### PR TITLE
Made structured output of validate command always set resource_body to a valid type

### DIFF
--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -10,31 +10,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testAuditResponseNoViolations() *validator.AuditResponse {
-	return &validator.AuditResponse{
-		Violations: []*validator.Violation{},
-	}
+func testNoViolations() []*validator.Violation {
+	return []*validator.Violation{}
 }
 
-func MockValidateAssetsNoViolations(ctx context.Context, assets []google.Asset, policyRootPath string) (*validator.AuditResponse, error) {
-	return testAuditResponseNoViolations(), nil
+func MockValidateAssetsNoViolations(ctx context.Context, assets []google.Asset, policyRootPath string) ([]*validator.Violation, error) {
+	return testNoViolations(), nil
 }
 
-func testAuditResponseWithViolations() *validator.AuditResponse {
-	return &validator.AuditResponse{
-		Violations: []*validator.Violation{
-			&validator.Violation{
-				Constraint: "GCPAlwaysViolatesConstraintV1.always_violates_project_match_target",
-				Resource:   "//bigtable.googleapis.com/projects/my-project/instances/tf-instance",
-				Message:    "Constraint GCPAlwaysViolatesConstraintV1.always_violates_project_match_target on resource //bigtable.googleapis.com/projects/my-project/instances/tf-instance",
-				Severity:   "high",
-			},
+func testWithViolations() []*validator.Violation {
+	return []*validator.Violation{
+		&validator.Violation{
+			Constraint: "GCPAlwaysViolatesConstraintV1.always_violates_project_match_target",
+			Resource:   "//bigtable.googleapis.com/projects/my-project/instances/tf-instance",
+			Message:    "Constraint GCPAlwaysViolatesConstraintV1.always_violates_project_match_target on resource //bigtable.googleapis.com/projects/my-project/instances/tf-instance",
+			Severity:   "high",
 		},
 	}
 }
 
-func MockValidateAssetsWithViolations(ctx context.Context, assets []google.Asset, policyRootPath string) (*validator.AuditResponse, error) {
-	return testAuditResponseWithViolations(), nil
+func MockValidateAssetsWithViolations(ctx context.Context, assets []google.Asset, policyRootPath string) ([]*validator.Violation, error) {
+	return testWithViolations(), nil
 }
 
 func TestValidateRun(t *testing.T) {
@@ -76,10 +72,10 @@ func TestValidateRun(t *testing.T) {
 	a.Contains(output, "resource_body")
 	a.Len(output["resource_body"], 1)
 
-	var expectedAuditResponse map[string]interface{}
-	expectedAuditResponseJSON, _ := json.Marshal(testAuditResponseWithViolations())
-	json.Unmarshal(expectedAuditResponseJSON, &expectedAuditResponse)
-	a.Equal(expectedAuditResponse["violations"], output["resource_body"])
+	var expectedViolations []interface{}
+	expectedViolationsJSON, _ := json.Marshal(testWithViolations())
+	json.Unmarshal(expectedViolationsJSON, &expectedViolations)
+	a.Equal(expectedViolations, output["resource_body"])
 }
 
 func TestValidateRunNoViolations(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.uber.org/zap v1.19.1
 	google.golang.org/api v0.56.0
 	google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71
+	google.golang.org/protobuf v1.27.1 // indirect
 )
 
 go 1.14

--- a/tfgcv/proto_test.go
+++ b/tfgcv/proto_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	"github.com/forseti-security/config-validator/pkg/api/validator"
-	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/proto"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/cloud/asset/v1"
 )


### PR DESCRIPTION
Simplified return value for ValidateAssetsFunc to be a slice of violations instead of an AuditResponse. This makes it easier to see that the violations shouldn't be a nil slice, which would be serialized to null instead of []. (resource_body must be an object or array, not null.)

This is related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/255