### PR TITLE
Fixed replacement of placeholders in tests

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -150,7 +150,7 @@ func normalizeAssets(t *testing.T, got []google.Asset, offline bool) []byte {
 		}
 	}
 	// Replace placeholder in names.
-	re := regexp.MustCompile(`/placeholder-.*`)
+	re := regexp.MustCompile(`/placeholder-[^/]+`)
 	for i := range got {
 		got[i].Name = re.ReplaceAllString(got[i].Name, "/placeholder-foobar")
 	}


### PR DESCRIPTION
The old regex would replace all the text from the match until the end of the string; the new regex only replaces until the next slash (or end of string. So for example, /placeholder-awkelrj/child/child-name was previously turned into /placeholder-foobar and will now be /placeholder-foobar/child/child-name

This came up while reviewing #328 - it impacts the crypto key IAM tests.