### PR TITLE
Fixed ordering issues in test result comparison

### DIFF
--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -186,9 +186,9 @@ func TestCLI(t *testing.T) {
 type compareConvertOutputFunc func(t *testing.T, expected []google.Asset, actual []google.Asset, offline bool)
 
 func compareUnmergedConvertOutput(t *testing.T, expected []google.Asset, actual []google.Asset, offline bool) {
-	expectedJSON := normalizeAssets(t, expected, offline)
-	actualJSON := normalizeAssets(t, actual, offline)
-	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+	expectedAssets := normalizeAssets(t, expected, offline)
+	actualAssets := normalizeAssets(t, actual, offline)
+	require.ElementsMatch(t, expectedAssets, actualAssets)
 }
 
 // For merged IAM members, only consider whether the expected members are present.
@@ -227,9 +227,9 @@ func compareMergedIamMemberOutput(t *testing.T, expected []google.Asset, actual 
 		normalizedActual = append(normalizedActual, normalizedActualAsset)
 	}
 
-	expectedJSON := normalizeAssets(t, expected, offline)
-	actualJSON := normalizeAssets(t, normalizedActual, offline)
-	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+	expectedAssets := normalizeAssets(t, expected, offline)
+	actualAssets := normalizeAssets(t, normalizedActual, offline)
+	require.ElementsMatch(t, expectedAssets, actualAssets)
 }
 
 // For merged IAM bindings, only consider whether the expected bindings are as expected.
@@ -257,9 +257,9 @@ func compareMergedIamBindingOutput(t *testing.T, expected []google.Asset, actual
 		normalizedActual = append(normalizedActual, normalizedActualAsset)
 	}
 
-	expectedJSON := normalizeAssets(t, expected, offline)
-	actualJSON := normalizeAssets(t, normalizedActual, offline)
-	require.JSONEq(t, string(expectedJSON), string(actualJSON))
+	expectedAssets := normalizeAssets(t, expected, offline)
+	actualAssets := normalizeAssets(t, normalizedActual, offline)
+	require.ElementsMatch(t, expectedAssets, actualAssets)
 }
 
 func testConvertCommand(t *testing.T, dir, name string, offline bool, compare compareConvertOutputFunc) {

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -55,8 +55,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_storage_bucket"},
 		{name: "example_storage_bucket_iam_binding"},
 		{name: "example_storage_bucket_iam_member"},
-		// This test is flakey - see https://github.com/GoogleCloudPlatform/terraform-validator/issues/259
-		// {name: "example_storage_bucket_iam_member_random_suffix"},
+		{name: "example_storage_bucket_iam_member_random_suffix"},
 		{name: "example_storage_bucket_iam_policy"},
 		{name: "full_compute_firewall"},
 		{name: "full_compute_instance"},
@@ -99,9 +98,9 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
 			}
 
-			gotJSON := normalizeAssets(t, got, true)
-			wantJSON := normalizeAssets(t, want, true)
-			require.JSONEq(t, string(wantJSON), string(gotJSON))
+			expectedAssets := normalizeAssets(t, got, true)
+			actualAssets := normalizeAssets(t, want, true)
+			require.ElementsMatch(t, actualAssets, expectedAssets)
 		})
 	}
 }


### PR DESCRIPTION
Switched to using ElementsMatch from testify to do a comparison of elements without caring about order. This required normalizing to JSON and back to ensure conformity of the nested structures.

Fixes https://github.com/GoogleCloudPlatform/terraform-validator/issues/259