### PR TITLE
Updated references to bucket_policy_only (which is removed in 4.0.0)

### DIFF
--- a/test/read_planned_assets/tf0_12plan.allcoverage.json
+++ b/test/read_planned_assets/tf0_12plan.allcoverage.json
@@ -1248,7 +1248,7 @@
           ]
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
 
           ],

--- a/test/read_planned_assets/tf0_12plan.applied.json
+++ b/test/read_planned_assets/tf0_12plan.applied.json
@@ -200,7 +200,7 @@
           "provider_name": "google",
           "schema_version": 0,
           "values": {
-            "bucket_policy_only": true,
+            "uniform_bucket_level_access": true,
             "cors": [
               {
                 "max_age_seconds": 0,
@@ -625,7 +625,7 @@
           "no-op"
         ],
         "before": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -665,7 +665,7 @@
           ]
         },
         "after": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -974,7 +974,7 @@
             "provider_name": "google",
             "schema_version": 0,
             "values": {
-              "bucket_policy_only": true,
+              "uniform_bucket_level_access": true,
               "cors": [
                 {
                   "max_age_seconds": 0,

--- a/test/read_planned_assets/tf1_0plan.allcoverage.json
+++ b/test/read_planned_assets/tf1_0plan.allcoverage.json
@@ -1248,7 +1248,7 @@
           ]
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
 
           ],

--- a/test/read_planned_assets/tf1_0plan.applied.json
+++ b/test/read_planned_assets/tf1_0plan.applied.json
@@ -250,7 +250,7 @@
           "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 0,
           "values": {
-            "bucket_policy_only": true,
+            "uniform_bucket_level_access": true,
             "cors": [
               {
                 "max_age_seconds": 0,
@@ -346,7 +346,7 @@
           "update"
         ],
         "before": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -386,7 +386,7 @@
           ]
         },
         "after": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -935,7 +935,7 @@
           "no-op"
         ],
         "before": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -975,7 +975,7 @@
           ]
         },
         "after": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 0,
@@ -1384,7 +1384,7 @@
             "provider_name": "registry.terraform.io/hashicorp/google",
             "schema_version": 0,
             "values": {
-              "bucket_policy_only": true,
+              "uniform_bucket_level_access": true,
               "cors": [
                 {
                   "max_age_seconds": 0,

--- a/testdata/templates/example_storage_bucket.tfplan.json
+++ b/testdata/templates/example_storage_bucket.tfplan.json
@@ -70,7 +70,7 @@
           ]
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [],
           "encryption": [],
           "id": true,

--- a/testdata/templates/example_storage_bucket_iam_binding.tfplan.json
+++ b/testdata/templates/example_storage_bucket_iam_binding.tfplan.json
@@ -80,7 +80,7 @@
           "website": []
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [],
           "encryption": [],
           "id": true,

--- a/testdata/templates/example_storage_bucket_iam_member.tfplan.json
+++ b/testdata/templates/example_storage_bucket_iam_member.tfplan.json
@@ -78,7 +78,7 @@
           "website": []
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [],
           "encryption": [],
           "id": true,

--- a/testdata/templates/example_storage_bucket_iam_member_random_suffix.tfplan.json
+++ b/testdata/templates/example_storage_bucket_iam_member_random_suffix.tfplan.json
@@ -96,7 +96,7 @@
           "website": []
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [],
           "encryption": [],
           "id": true,

--- a/testdata/templates/example_storage_bucket_iam_policy.tfplan.json
+++ b/testdata/templates/example_storage_bucket_iam_policy.tfplan.json
@@ -76,7 +76,7 @@
           "website": []
         },
         "after_unknown": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [],
           "encryption": [],
           "id": true,

--- a/testdata/templates/full_storage_bucket.tf
+++ b/testdata/templates/full_storage_bucket.tf
@@ -31,7 +31,7 @@ resource "google_storage_bucket" "full-list-default" {
   name     = "image-store-bucket"
   location = "EU"
 
-  bucket_policy_only = true
+  uniform_bucket_level_access = true
   cors {
     origin          = ["test-origin1", "test-origin2"]
     method          = ["test-method1", "test-method2"]

--- a/testdata/templates/full_storage_bucket.tfplan.json
+++ b/testdata/templates/full_storage_bucket.tfplan.json
@@ -12,7 +12,7 @@
           "provider_name": "google",
           "schema_version": 0,
           "values": {
-            "bucket_policy_only": true,
+            "uniform_bucket_level_access": true,
             "cors": [
               {
                 "max_age_seconds": 42,
@@ -144,7 +144,7 @@
         ],
         "before": null,
         "after": {
-          "bucket_policy_only": true,
+          "uniform_bucket_level_access": true,
           "cors": [
             {
               "max_age_seconds": 42,
@@ -362,7 +362,7 @@
           "name": "full-list-default",
           "provider_config_key": "google",
           "expressions": {
-            "bucket_policy_only": {
+            "uniform_bucket_level_access": {
               "constant_value": true
             },
             "cors": [


### PR DESCRIPTION
follow-on work from https://github.com/GoogleCloudPlatform/magic-modules/pull/5340