### PR TITLE
Remove references to deleted SQL fields

### DIFF
--- a/test/read_planned_assets/tf0_12plan.allcoverage.json
+++ b/test/read_planned_assets/tf0_12plan.allcoverage.json
@@ -307,7 +307,6 @@
             "region": "us-central1",
             "settings": [
               {
-                "authorized_gae_applications": null,
                 "database_flags": [
 
                 ],
@@ -316,7 +315,6 @@
 
                 ],
                 "pricing_plan": "PER_USE",
-                "replication_type": "SYNCHRONOUS",
                 "tier": "db-f1-micro",
                 "user_labels": null
               }
@@ -1098,7 +1096,6 @@
           "region": "us-central1",
           "settings": [
             {
-              "authorized_gae_applications": null,
               "database_flags": [
 
               ],
@@ -1107,7 +1104,6 @@
 
               ],
               "pricing_plan": "PER_USE",
-              "replication_type": "SYNCHRONOUS",
               "tier": "db-f1-micro",
               "user_labels": null
             }
@@ -1120,7 +1116,6 @@
           "region": "us-central1",
           "settings": [
             {
-              "authorized_gae_applications": null,
               "database_flags": [
 
               ],
@@ -1129,7 +1124,6 @@
 
               ],
               "pricing_plan": "PER_USE",
-              "replication_type": "SYNCHRONOUS",
               "tier": "db-f1-micro",
               "user_labels": null
             }
@@ -1154,7 +1148,6 @@
               "activation_policy": true,
               "availability_type": true,
               "backup_configuration": true,
-              "crash_safe_replication": true,
               "database_flags": [
 
               ],

--- a/test/read_planned_assets/tf1_0plan.allcoverage.json
+++ b/test/read_planned_assets/tf1_0plan.allcoverage.json
@@ -307,7 +307,6 @@
             "region": "us-central1",
             "settings": [
               {
-                "authorized_gae_applications": null,
                 "database_flags": [
 
                 ],
@@ -316,7 +315,6 @@
 
                 ],
                 "pricing_plan": "PER_USE",
-                "replication_type": "SYNCHRONOUS",
                 "tier": "db-f1-micro",
                 "user_labels": null
               }
@@ -1098,7 +1096,6 @@
           "region": "us-central1",
           "settings": [
             {
-              "authorized_gae_applications": null,
               "database_flags": [
 
               ],
@@ -1107,7 +1104,6 @@
 
               ],
               "pricing_plan": "PER_USE",
-              "replication_type": "SYNCHRONOUS",
               "tier": "db-f1-micro",
               "user_labels": null
             }
@@ -1120,7 +1116,6 @@
           "region": "us-central1",
           "settings": [
             {
-              "authorized_gae_applications": null,
               "database_flags": [
 
               ],
@@ -1129,7 +1124,6 @@
 
               ],
               "pricing_plan": "PER_USE",
-              "replication_type": "SYNCHRONOUS",
               "tier": "db-f1-micro",
               "user_labels": null
             }
@@ -1154,7 +1148,6 @@
               "activation_policy": true,
               "availability_type": true,
               "backup_configuration": true,
-              "crash_safe_replication": true,
               "database_flags": [
 
               ],

--- a/testdata/templates/example_sql_database_instance.tfplan.json
+++ b/testdata/templates/example_sql_database_instance.tfplan.json
@@ -87,10 +87,8 @@
           "settings": [
             {
               "activation_policy": true,
-              "authorized_gae_applications": true,
               "availability_type": true,
               "backup_configuration": true,
-              "crash_safe_replication": true,
               "database_flags": [],
               "disk_size": true,
               "disk_type": true,
@@ -98,7 +96,6 @@
               "ip_configuration": true,
               "location_preference": true,
               "maintenance_window": [],
-              "replication_type": true,
               "user_labels": true,
               "version": true
             }

--- a/testdata/templates/full_sql_database_instance.json
+++ b/testdata/templates/full_sql_database_instance.json
@@ -31,10 +31,7 @@
         },
         "settings": {
           "activationPolicy": "test-activation_policy",
-          "authorizedGaeApplications": [
-            "test-authorized_gae_application1",
-            "test-authorized_gae_application2"
-          ],
+
           "availabilityType": "REGIONAL",
           "backupConfiguration": {
             "binaryLogEnabled": true,
@@ -42,7 +39,6 @@
             "startTime": "42:42",
             "location": "us"
           },
-          "crashSafeReplicationEnabled": true,
           "dataDiskSizeGb": "42",
           "dataDiskType": "test-disk_type",
           "databaseFlags": [
@@ -81,7 +77,6 @@
             "updateTrack": "test-update_track"
           },
           "pricingPlan": "test-pricing_plan",
-          "replicationType": "test-replication_type",
           "storageAutoResize": true,
           "tier": "db-f1-micro",
           "userLabels": {

--- a/testdata/templates/full_sql_database_instance.tf
+++ b/testdata/templates/full_sql_database_instance.tf
@@ -54,7 +54,6 @@ resource "google_sql_database_instance" "master" {
   }
   settings {
     activation_policy           = "test-activation_policy"
-    authorized_gae_applications = ["test-authorized_gae_application1", "test-authorized_gae_application2"]
     availability_type           = "REGIONAL"
     backup_configuration {
       binary_log_enabled = true
@@ -62,7 +61,6 @@ resource "google_sql_database_instance" "master" {
       start_time         = "42:42"
       location           = "us"
     }
-    crash_safe_replication = true
     database_flags {
       name  = "test-name1"
       value = "test-value1"
@@ -99,7 +97,6 @@ resource "google_sql_database_instance" "master" {
       update_track = "test-update_track"
     }
     pricing_plan     = "test-pricing_plan"
-    replication_type = "test-replication_type"
     tier             = "db-f1-micro"
     user_labels = {
       user_labels_foo = "user_labels_bar"

--- a/testdata/templates/full_sql_database_instance.tfplan.json
+++ b/testdata/templates/full_sql_database_instance.tfplan.json
@@ -80,10 +80,6 @@
             "settings": [
               {
                 "activation_policy": "test-activation_policy",
-                "authorized_gae_applications": [
-                  "test-authorized_gae_application1",
-                  "test-authorized_gae_application2"
-                ],
                 "availability_type": "REGIONAL",
                 "backup_configuration": [
                   {
@@ -93,7 +89,6 @@
                     "location": "us"
                   }
                 ],
-                "crash_safe_replication": true,
                 "database_flags": [
                   {
                     "name": "test-name1",
@@ -139,7 +134,6 @@
                   }
                 ],
                 "pricing_plan": "test-pricing_plan",
-                "replication_type": "test-replication_type",
                 "tier": "db-f1-micro",
                 "user_labels": {
                   "user_labels_foo": "user_labels_bar"
@@ -272,10 +266,6 @@
           "settings": [
             {
               "activation_policy": "test-activation_policy",
-              "authorized_gae_applications": [
-                "test-authorized_gae_application1",
-                "test-authorized_gae_application2"
-              ],
               "availability_type": "REGIONAL",
               "backup_configuration": [
                 {
@@ -285,7 +275,6 @@
                   "location": "us"
                 }
               ],
-              "crash_safe_replication": true,
               "database_flags": [
                 {
                   "name": "test-name1",
@@ -331,7 +320,6 @@
                 }
               ],
               "pricing_plan": "test-pricing_plan",
-              "replication_type": "test-replication_type",
               "tier": "db-f1-micro",
               "user_labels": {
                 "user_labels_foo": "user_labels_bar"
@@ -356,10 +344,6 @@
           "service_account_email_address": true,
           "settings": [
             {
-              "authorized_gae_applications": [
-                false,
-                false
-              ],
               "backup_configuration": [
                 {}
               ],
@@ -527,12 +511,6 @@
                 "activation_policy": {
                   "constant_value": "test-activation_policy"
                 },
-                "authorized_gae_applications": {
-                  "constant_value": [
-                    "test-authorized_gae_application1",
-                    "test-authorized_gae_application2"
-                  ]
-                },
                 "availability_type": {
                   "constant_value": "REGIONAL"
                 },
@@ -552,9 +530,6 @@
                     }
                   }
                 ],
-                "crash_safe_replication": {
-                  "constant_value": true
-                },
                 "database_flags": [
                   {
                     "name": {
@@ -646,9 +621,6 @@
                 ],
                 "pricing_plan": {
                   "constant_value": "test-pricing_plan"
-                },
-                "replication_type": {
-                  "constant_value": "test-replication_type"
                 },
                 "tier": {
                   "constant_value": "db-f1-micro"


### PR DESCRIPTION
Fixes failures introduced by https://github.com/GoogleCloudPlatform/magic-modules/pull/5364, at least partway.

`make test` stalled locally getting dependencies, so pushing to CI to see if it takes.