### PR TITLE
Fixed GetOk / GetOkExists behavior

### DIFF
--- a/converters/google/fake_resource_data_test.go
+++ b/converters/google/fake_resource_data_test.go
@@ -24,9 +24,9 @@ func TestFakeResourceData_kind(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name": "test-disk",
-		"type": "pd-ssd",
-		"zone": "us-central1-a",
+		"name":  "test-disk",
+		"type":  "pd-ssd",
+		"zone":  "us-central1-a",
 		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
@@ -42,9 +42,9 @@ func TestFakeResourceData_id(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name": "test-disk",
-		"type": "pd-ssd",
-		"zone": "us-central1-a",
+		"name":  "test-disk",
+		"type":  "pd-ssd",
+		"zone":  "us-central1-a",
 		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
@@ -60,9 +60,9 @@ func TestFakeResourceData_get(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name": "test-disk",
-		"type": "pd-ssd",
-		"zone": "us-central1-a",
+		"name":  "test-disk",
+		"type":  "pd-ssd",
+		"zone":  "us-central1-a",
 		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
@@ -78,9 +78,9 @@ func TestFakeResourceData_getOkOk(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name": "test-disk",
-		"type": "pd-ssd",
-		"zone": "us-central1-a",
+		"name":  "test-disk",
+		"type":  "pd-ssd",
+		"zone":  "us-central1-a",
 		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
@@ -98,9 +98,9 @@ func TestFakeResourceData_getOkNonexistentField(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name": "test-disk",
-		"type": "pd-ssd",
-		"zone": "us-central1-a",
+		"name":  "test-disk",
+		"type":  "pd-ssd",
+		"zone":  "us-central1-a",
 		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}

--- a/converters/google/fake_resource_data_test.go
+++ b/converters/google/fake_resource_data_test.go
@@ -24,10 +24,10 @@ func TestFakeResourceData_kind(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":                      "test-disk",
-		"type":                      "pd-ssd",
-		"zone":                      "us-central1-a",
-		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name": "test-disk",
+		"type": "pd-ssd",
+		"zone": "us-central1-a",
+		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -42,10 +42,10 @@ func TestFakeResourceData_id(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":                      "test-disk",
-		"type":                      "pd-ssd",
-		"zone":                      "us-central1-a",
-		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name": "test-disk",
+		"type": "pd-ssd",
+		"zone": "us-central1-a",
+		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -60,10 +60,10 @@ func TestFakeResourceData_get(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":                      "test-disk",
-		"type":                      "pd-ssd",
-		"zone":                      "us-central1-a",
-		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name": "test-disk",
+		"type": "pd-ssd",
+		"zone": "us-central1-a",
+		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -78,10 +78,10 @@ func TestFakeResourceData_getOkOk(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":                      "test-disk",
-		"type":                      "pd-ssd",
-		"zone":                      "us-central1-a",
-		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name": "test-disk",
+		"type": "pd-ssd",
+		"zone": "us-central1-a",
+		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -98,10 +98,10 @@ func TestFakeResourceData_getOkNonexistentField(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":                      "test-disk",
-		"type":                      "pd-ssd",
-		"zone":                      "us-central1-a",
-		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name": "test-disk",
+		"type": "pd-ssd",
+		"zone": "us-central1-a",
+		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(

--- a/converters/google/fake_resource_data_test.go
+++ b/converters/google/fake_resource_data_test.go
@@ -24,10 +24,10 @@ func TestFakeResourceData_kind(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":  "test-disk",
-		"type":  "pd-ssd",
-		"zone":  "us-central1-a",
-		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -35,18 +35,17 @@ func TestFakeResourceData_kind(t *testing.T) {
 		p.ResourcesMap["google_compute_disk"].Schema,
 		values,
 	)
-	assert.Equal(t, d.Kind(), "google_compute_disk")
+	assert.Equal(t, "google_compute_disk", d.Kind())
 }
-
 
 func TestFakeResourceData_id(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":  "test-disk",
-		"type":  "pd-ssd",
-		"zone":  "us-central1-a",
-		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -57,15 +56,14 @@ func TestFakeResourceData_id(t *testing.T) {
 	assert.Equal(t, d.Id(), "")
 }
 
-
 func TestFakeResourceData_get(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":  "test-disk",
-		"type":  "pd-ssd",
-		"zone":  "us-central1-a",
-		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -76,15 +74,14 @@ func TestFakeResourceData_get(t *testing.T) {
 	assert.Equal(t, d.Get("name"), "test-disk")
 }
 
-
 func TestFakeResourceData_getOkOk(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":  "test-disk",
-		"type":  "pd-ssd",
-		"zone":  "us-central1-a",
-		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -93,19 +90,18 @@ func TestFakeResourceData_getOkOk(t *testing.T) {
 		values,
 	)
 	res, ok := d.GetOk("name")
-	assert.Equal(t, res, "test-disk")
+	assert.Equal(t, "test-disk", res)
 	assert.True(t, ok)
 }
 
-
-func TestFakeResourceData_getOkNotOk(t *testing.T) {
+func TestFakeResourceData_getOkNonexistentField(t *testing.T) {
 	p := provider.Provider()
 
 	values := map[string]interface{}{
-		"name":  "test-disk",
-		"type":  "pd-ssd",
-		"zone":  "us-central1-a",
-		"image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
 		"physical_block_size_bytes": 4096,
 	}
 	d := NewFakeResourceData(
@@ -115,5 +111,216 @@ func TestFakeResourceData_getOkNotOk(t *testing.T) {
 	)
 	res, ok := d.GetOk("incorrect")
 	assert.Nil(t, res)
+	assert.False(t, ok)
+}
+
+func TestFakeResourceData_getOkEmptyString(t *testing.T) {
+	p := provider.Provider()
+
+	values := map[string]interface{}{
+		"name":                      "test-disk",
+		"type":                      "pd-ssd",
+		"zone":                      "us-central1-a",
+		"image":                     "",
+		"physical_block_size_bytes": 4096,
+	}
+	d := NewFakeResourceData(
+		"google_compute_disk",
+		p.ResourcesMap["google_compute_disk"].Schema,
+		values,
+	)
+	res, ok := d.GetOk("image")
+	assert.Equal(t, "", res)
+	assert.False(t, ok)
+}
+
+func TestFakeResourceData_getOkUnsetString(t *testing.T) {
+	p := provider.Provider()
+
+	values := map[string]interface{}{
+		"name":     "my-node-pool",
+		"location": "us-central1",
+		"cluster":  "projects/my-project-id/global/clusters/my-gke-cluster",
+		"config": map[string]interface{}{
+			"machineType": "n1-standard-1",
+			"metadata": map[string]string{
+				"disable-legacy-endpoints": "true",
+			},
+			"oauthScopes": []string{
+				"https://www.googleapis.com/auth/cloud-platform",
+			},
+			"preemptible": true,
+		},
+	}
+	d := NewFakeResourceData(
+		"google_container_cluster",
+		p.ResourcesMap["google_container_cluster"].Schema,
+		values,
+	)
+	res, ok := d.GetOk("subnetwork")
+	assert.Equal(t, "", res)
+	assert.False(t, ok)
+}
+
+func TestFakeResourceData_getOkTypeObject(t *testing.T) {
+	p := provider.Provider()
+
+	values := map[string]interface{}{
+		"advanced_machine_features": []interface{}{},
+		"allow_stopping_for_update": nil,
+		"attached_disk": []interface{}{
+			map[string]interface{}{
+				"device_name":             "test-device_name",
+				"disk_encryption_key_raw": nil,
+				"kms_key_self_link":       "test-kms_key_self_link",
+				"mode":                    "READ_ONLY",
+				"source":                  "test-source",
+			},
+			map[string]interface{}{
+				"disk_encryption_key_raw": nil,
+				"mode":                    "READ_WRITE",
+				"source":                  "test-source2",
+			},
+		},
+		"boot_disk": []interface{}{
+			map[string]interface{}{
+				"auto_delete":             true,
+				"disk_encryption_key_raw": nil,
+				"initialize_params": []interface{}{
+					map[string]interface{}{
+						"image": "debian-cloud/debian-9",
+					},
+				},
+				"mode": "READ_WRITE",
+			},
+		},
+		"can_ip_forward":          false,
+		"deletion_protection":     false,
+		"description":             nil,
+		"desired_status":          nil,
+		"enable_display":          nil,
+		"hostname":                nil,
+		"labels":                  nil,
+		"machine_type":            "n1-standard-1",
+		"metadata":                nil,
+		"metadata_startup_script": nil,
+		"name":                    "test",
+		"network_interface": []interface{}{
+			map[string]interface{}{
+				"access_config": []interface{}{
+					map[string]interface{}{
+						"public_ptr_domain_name": nil,
+					},
+				},
+				"alias_ip_range":     []interface{}{},
+				"ipv6_access_config": []interface{}{},
+				"network":            "default",
+				"nic_type":           nil,
+			},
+		},
+		"resource_policies": nil,
+		"scratch_disk": []interface{}{
+			map[string]interface{}{
+				"interface": "SCSI",
+			},
+		},
+		"service_account":          []interface{}{},
+		"shielded_instance_config": []interface{}{},
+		"tags": []interface{}{
+			"bar",
+			"foo",
+		},
+		"timeouts": nil,
+		"zone":     "us-central1-a",
+	}
+	d := NewFakeResourceData(
+		"google_compute_instance",
+		p.ResourcesMap["google_compute_instance"].Schema,
+		values,
+	)
+	res, ok := d.GetOk("attached_disk.0")
+	assert.Equal(t, map[string]interface{}{
+		"device_name":                "test-device_name",
+		"disk_encryption_key_raw":    "",
+		"disk_encryption_key_sha256": "",
+		"kms_key_self_link":          "test-kms_key_self_link",
+		"mode":                       "READ_ONLY",
+		"source":                     "test-source",
+	}, res)
+	assert.True(t, ok)
+}
+
+func TestFakeResourceData_getOknsetTypeObject(t *testing.T) {
+	p := provider.Provider()
+
+	values := map[string]interface{}{
+		"advanced_machine_features": []interface{}{},
+		"allow_stopping_for_update": nil,
+		"attached_disk":             []interface{}{},
+		"boot_disk": []interface{}{
+			map[string]interface{}{
+				"auto_delete":             true,
+				"disk_encryption_key_raw": nil,
+				"initialize_params": []interface{}{
+					map[string]interface{}{
+						"image": "debian-cloud/debian-9",
+					},
+				},
+				"mode": "READ_WRITE",
+			},
+		},
+		"can_ip_forward":          false,
+		"deletion_protection":     false,
+		"description":             nil,
+		"desired_status":          nil,
+		"enable_display":          nil,
+		"hostname":                nil,
+		"labels":                  nil,
+		"machine_type":            "n1-standard-1",
+		"metadata":                nil,
+		"metadata_startup_script": nil,
+		"name":                    "test",
+		"network_interface": []interface{}{
+			map[string]interface{}{
+				"access_config": []interface{}{
+					map[string]interface{}{
+						"public_ptr_domain_name": nil,
+					},
+				},
+				"alias_ip_range":     []interface{}{},
+				"ipv6_access_config": []interface{}{},
+				"network":            "default",
+				"nic_type":           nil,
+			},
+		},
+		"resource_policies": nil,
+		"scratch_disk": []interface{}{
+			map[string]interface{}{
+				"interface": "SCSI",
+			},
+		},
+		"service_account":          []interface{}{},
+		"shielded_instance_config": []interface{}{},
+		"tags": []interface{}{
+			"bar",
+			"foo",
+		},
+		"timeouts": nil,
+		"zone":     "us-central1-a",
+	}
+	d := NewFakeResourceData(
+		"google_compute_instance",
+		p.ResourcesMap["google_compute_instance"].Schema,
+		values,
+	)
+	res, ok := d.GetOk("attached_disk.0")
+	assert.Equal(t, map[string]interface{}{
+		"device_name":                "",
+		"disk_encryption_key_raw":    "",
+		"disk_encryption_key_sha256": "",
+		"kms_key_self_link":          "",
+		"mode":                       "",
+		"source":                     "",
+	}, res)
 	assert.False(t, ok)
 }

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -63,6 +63,7 @@ func TestCLI(t *testing.T) {
 		{name: "example_bigquery_dataset"},
 		{name: "example_bigtable_instance"},
 		{name: "example_compute_disk"},
+		{name: "example_compute_disk_empty_image"},
 		{name: "example_compute_firewall"},
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_instance"},

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -105,8 +105,8 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
 			}
 
-			expectedAssets := normalizeAssets(t, got, true)
-			actualAssets := normalizeAssets(t, want, true)
+			expectedAssets := normalizeAssets(t, want, true)
+			actualAssets := normalizeAssets(t, got, true)
 			require.ElementsMatch(t, actualAssets, expectedAssets)
 		})
 	}

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -24,6 +24,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_bigquery_dataset"},
 		{name: "example_bigtable_instance"},
 		{name: "example_compute_disk"},
+		{name: "example_compute_disk_empty_image"},
 		{name: "example_compute_firewall"},
 		// This test can't run in offline mode
 		// {name: "example_compute_instance"},

--- a/testdata/templates/bucket.json
+++ b/testdata/templates/bucket.json
@@ -9,8 +9,9 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": false

--- a/testdata/templates/example_compute_disk_empty_image.json
+++ b/testdata/templates/example_compute_disk_empty_image.json
@@ -14,7 +14,6 @@
         },
         "name": "test-disk",
         "physicalBlockSizeBytes": 4096,
-        "sourceImage": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
         "type": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
         "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
       }

--- a/testdata/templates/example_compute_disk_empty_image.json
+++ b/testdata/templates/example_compute_disk_empty_image.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/zones/us-central1-a/disks/test-disk",
+    "asset_type": "compute.googleapis.com/Disk",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Disk",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "labels": {
+          "environment": "dev"
+        },
+        "name": "test-disk",
+        "physicalBlockSizeBytes": 4096,
+        "sourceImage": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+        "type": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
+        "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_compute_disk_empty_image.tf
+++ b/testdata/templates/example_compute_disk_empty_image.tf
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_disk" "default" {
+  name  = "test-disk"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = ""
+  labels = {
+    environment = "dev"
+  }
+  physical_block_size_bytes = 4096
+}

--- a/testdata/templates/example_compute_disk_empty_image.tfplan.json
+++ b/testdata/templates/example_compute_disk_empty_image.tfplan.json
@@ -1,0 +1,131 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.12.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_disk.default",
+          "mode": "managed",
+          "type": "google_compute_disk",
+          "name": "default",
+          "provider_name": "google",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "disk_encryption_key": [],
+            "disk_encryption_key_raw": null,
+            "image": "",
+            "labels": {
+              "environment": "dev"
+            },
+            "name": "test-disk",
+            "physical_block_size_bytes": 4096,
+            "snapshot": null,
+            "source_image_encryption_key": [],
+            "source_snapshot_encryption_key": [],
+            "timeouts": null,
+            "type": "pd-ssd",
+            "zone": "us-central1-a"
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_disk.default",
+      "mode": "managed",
+      "type": "google_compute_disk",
+      "name": "default",
+      "provider_name": "google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "disk_encryption_key": [],
+          "disk_encryption_key_raw": null,
+          "image": "",
+          "labels": {
+            "environment": "dev"
+          },
+          "name": "test-disk",
+          "physical_block_size_bytes": 4096,
+          "snapshot": null,
+          "source_image_encryption_key": [],
+          "source_snapshot_encryption_key": [],
+          "timeouts": null,
+          "type": "pd-ssd",
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "creation_timestamp": true,
+          "disk_encryption_key": [],
+          "disk_encryption_key_sha256": true,
+          "id": true,
+          "label_fingerprint": true,
+          "labels": {},
+          "last_attach_timestamp": true,
+          "last_detach_timestamp": true,
+          "project": true,
+          "self_link": true,
+          "size": true,
+          "source_image_encryption_key": [],
+          "source_image_id": true,
+          "source_snapshot_encryption_key": [],
+          "source_snapshot_id": true,
+          "users": true
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": "{{.Provider.project}}"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_disk.default",
+          "mode": "managed",
+          "type": "google_compute_disk",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "image": {
+              "constant_value": ""
+            },
+            "labels": {
+              "constant_value": {
+                "environment": "dev"
+              }
+            },
+            "name": {
+              "constant_value": "test-disk"
+            },
+            "physical_block_size_bytes": {
+              "constant_value": 4096
+            },
+            "type": {
+              "constant_value": "pd-ssd"
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/testdata/templates/example_compute_instance.json
+++ b/testdata/templates/example_compute_instance.json
@@ -10,14 +10,6 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "canIpForward": false,
-        "displayDevice": {
-          "enableDisplay": false
-        },
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": false,
-          "enableSecureBoot": false,
-          "enableVtpm": false
-        },
         "deletionProtection": false,
         "disks": [
           {

--- a/testdata/templates/example_project_in_folder.json
+++ b/testdata/templates/example_project_in_folder.json
@@ -1,21 +1,5 @@
 [
     {
-      "name": "//cloudbilling.googleapis.com/projects/foobat/billingInfo",
-      "asset_type": "cloudbilling.googleapis.com/ProjectBillingInfo",
-      "ancestry_path": "organization/unknown/folder/{{.FolderID}}/project/foobat",
-      "resource": {
-        "version": "v1",
-        "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/cloudbilling/v1/rest",
-        "discovery_name": "ProjectBillingInfo",
-        "parent": "//cloudresourcemanager.googleapis.com/projects/foobat",
-        "data": {
-          "billingAccountName": "billingAccounts/",
-          "name": "projects/foobat/billingInfo",
-          "projectId": "foobat"
-        }
-      }
-    },
-    {
       "name": "//cloudresourcemanager.googleapis.com/projects/foobat",
       "asset_type": "cloudresourcemanager.googleapis.com/Project",
       "ancestry_path": "organization/unknown/folder/{{.FolderID}}/project/foobat",

--- a/testdata/templates/example_project_in_org.json
+++ b/testdata/templates/example_project_in_org.json
@@ -1,21 +1,5 @@
 [
     {
-      "name": "//cloudbilling.googleapis.com/projects/foobat/billingInfo",
-      "asset_type": "cloudbilling.googleapis.com/ProjectBillingInfo",
-      "ancestry_path": "organization/{{.OrgID}}/project/foobat",
-      "resource": {
-        "version": "v1",
-        "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/cloudbilling/v1/rest",
-        "discovery_name": "ProjectBillingInfo",
-        "parent": "//cloudresourcemanager.googleapis.com/projects/foobat",
-        "data": {
-          "billingAccountName": "billingAccounts/",
-          "name": "projects/foobat/billingInfo",
-          "projectId": "foobat"
-        }
-      }
-    },
-    {
       "name": "//cloudresourcemanager.googleapis.com/projects/foobat",
       "asset_type": "cloudresourcemanager.googleapis.com/Project",
       "ancestry_path": "organization/{{.OrgID}}/project/foobat",

--- a/testdata/templates/example_storage_bucket.json
+++ b/testdata/templates/example_storage_bucket.json
@@ -9,13 +9,14 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": false
           }
         },
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "location": "EU",
         "name": "image-store-bucket",
         "project": "{{.Provider.project}}",

--- a/testdata/templates/example_storage_bucket_iam_binding.json
+++ b/testdata/templates/example_storage_bucket_iam_binding.json
@@ -9,13 +9,14 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": true
           }
         },
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "location": "EU",
         "name": "fake-bucket-123456",
         "project": "{{.Provider.project}}",

--- a/testdata/templates/example_storage_bucket_iam_member.json
+++ b/testdata/templates/example_storage_bucket_iam_member.json
@@ -9,13 +9,14 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": true
           }
         },
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "location": "EU",
         "name": "fake-bucket-123456",
         "project": "{{.Provider.project}}",

--- a/testdata/templates/example_storage_bucket_iam_member_random_suffix.json
+++ b/testdata/templates/example_storage_bucket_iam_member_random_suffix.json
@@ -9,13 +9,14 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": true
           }
         },
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "location": "EU",
         "project": "{{.Provider.project}}",
         "storageClass": "STANDARD"

--- a/testdata/templates/example_storage_bucket_iam_policy.json
+++ b/testdata/templates/example_storage_bucket_iam_policy.json
@@ -9,13 +9,14 @@
       "discovery_name": "Bucket",
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
-        "billing": {},
         "iamConfiguration": {
           "uniformBucketLevelAccess": {
             "enabled": true
           }
         },
-        "lifecycle": {},
+        "lifecycle": {
+          "rule": []
+        },
         "location": "EU",
         "name": "fake-bucket-123456",
         "project": "{{.Provider.project}}",

--- a/testdata/templates/full_compute_instance.json
+++ b/testdata/templates/full_compute_instance.json
@@ -10,9 +10,6 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "canIpForward": true,
-        "displayDevice": {
-          "enableDisplay": false
-        },
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true,
           "enableSecureBoot": true,
@@ -153,14 +150,6 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "canIpForward": false,
-        "displayDevice": {
-          "enableDisplay": false
-        },
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": false,
-          "enableSecureBoot": false,
-          "enableVtpm": false
-        },
         "deletionProtection": false,
         "disks": [
           {

--- a/testdata/templates/instance.json
+++ b/testdata/templates/instance.json
@@ -10,14 +10,6 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "canIpForward": false,
-        "displayDevice": {
-          "enableDisplay": false
-        },
-        "shieldedInstanceConfig": {
-          "enableIntegrityMonitoring": false,
-          "enableSecureBoot": false,
-          "enableVtpm": false
-        },
         "deletionProtection": false,
         "disks": [
           {


### PR DESCRIPTION
Resolved #113. Made FakeResourceData behave more consistently with Terraform core in terms of the values it produces. This ensures that expanders written with Terraform [ResourceData](https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource_data.go) structs in mind behave properly in TFV as well.

Some test data had to be updated due to the code now properly excluding empty data.

I'm sorry for the long PR; most of it is new tests.