### PR TITLE
Add support for google_compute_snapshot

### DIFF
--- a/converters/google/resources/resource_converters.go
+++ b/converters/google/resources/resource_converters.go
@@ -29,6 +29,7 @@ func ResourceConverters() map[string][]ResourceConverter {
 		"google_compute_global_forwarding_rule":            {resourceConverterComputeGlobalForwardingRule()},
 		"google_compute_instance":                          {resourceConverterComputeInstance()},
 		"google_compute_network":                           {resourceConverterComputeNetwork()},
+		"google_compute_snapshot":                          {resourceConverterComputeSnapshot()},
 		"google_compute_subnetwork":                        {resourceConverterComputeSubnetwork()},
 		"google_dns_managed_zone":                          {resourceConverterDNSManagedZone()},
 		"google_storage_bucket":                            {resourceConverterStorageBucket()},

--- a/docs/supported_resources.md
+++ b/docs/supported_resources.md
@@ -40,6 +40,7 @@ google_compute_network                           | compute.googleapis.com/Networ
 google_compute_region_disk_iam_binding           | compute.googleapis.com/RegionDisk
 google_compute_region_disk_iam_member            | compute.googleapis.com/RegionDisk
 google_compute_region_disk_iam_policy            | compute.googleapis.com/RegionDisk
+google_compute_snapshot                          | compute.googleapis.com/Snapshot
 google_compute_subnetwork                        | compute.googleapis.com/Subnetwork
 google_compute_subnetwork_iam_binding            | compute.googleapis.com/Subnetwork
 google_compute_subnetwork_iam_member             | compute.googleapis.com/Subnetwork

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -71,6 +71,7 @@ func TestCLI(t *testing.T) {
 		{name: "example_compute_forwarding_rule"},
 		{name: "example_compute_instance"},
 		{name: "example_compute_network"},
+		{name: "example_compute_snapshot"},
 		{name: "example_compute_subnetwork"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -32,6 +32,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		// This test can't run in offline mode
 		// {name: "example_compute_instance"},
 		{name: "example_compute_network"},
+		{name: "example_compute_snapshot"},
 		{name: "example_compute_subnetwork"},
 		// This test can't run in offline mode.
 		// {name: "example_compute_forwarding_rule"},

--- a/testdata/templates/example_compute_snapshot.json
+++ b/testdata/templates/example_compute_snapshot.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/snapshots/test-instance",
+    "asset_type": "compute.googleapis.com/Snapshot",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Snapshot",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "labels": {
+          "test-name": "test-value"
+        },
+        "name": "test-instance",
+        "sourceDisk": "projects/{{.Provider.project}}/zones/us-central1-a/disks/debian-disk",
+        "storageLocations": [
+          "us-central1"
+        ],
+        "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/zones/us-central1-a/disks/debian-disk",
+    "asset_type": "compute.googleapis.com/Disk",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "Disk",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "name": "debian-disk",
+        "sizeGb": 10,
+        "sourceImage": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+        "type": "projects/{{.Provider.project}}/zones/us-central1-a/diskTypes/pd-ssd",
+        "zone": "projects/{{.Provider.project}}/global/zones/us-central1-a"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_compute_snapshot.tf
+++ b/testdata/templates/example_compute_snapshot.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+provider "google" {
+  project = "{{.Provider.project}}"
+}
+
+resource "google_compute_snapshot" "default" {
+  name = "test-instance"
+
+  source_disk = google_compute_disk.default.name
+  zone  = "us-central1-a"
+  labels = {
+    test-name = "test-value"
+  }
+  storage_locations = ["us-central1"]
+}
+
+
+resource "google_compute_disk" "default" {
+  name  = "debian-disk"
+  image = "projects/debian-cloud/global/images/debian-8-jessie-v20170523"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+

--- a/testdata/templates/example_compute_snapshot.tfplan.json
+++ b/testdata/templates/example_compute_snapshot.tfplan.json
@@ -1,0 +1,252 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_disk.default",
+          "mode": "managed",
+          "type": "google_compute_disk",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "disk_encryption_key": [],
+            "image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+            "labels": null,
+            "name": "debian-disk",
+            "provisioned_iops": null,
+            "size": 10,
+            "snapshot": null,
+            "source_image_encryption_key": [],
+            "source_snapshot_encryption_key": [],
+            "timeouts": null,
+            "type": "pd-ssd",
+            "zone": "us-central1-a"
+          },
+          "sensitive_values": {
+            "disk_encryption_key": [],
+            "source_image_encryption_key": [],
+            "source_snapshot_encryption_key": [],
+            "users": []
+          }
+        },
+        {
+          "address": "google_compute_snapshot.default",
+          "mode": "managed",
+          "type": "google_compute_snapshot",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "description": null,
+            "labels": {
+              "test-name": "test-value"
+            },
+            "name": "test-instance",
+            "snapshot_encryption_key": [],
+            "source_disk": "debian-disk",
+            "source_disk_encryption_key": [],
+            "storage_locations": [
+              "us-central1"
+            ],
+            "timeouts": null,
+            "zone": "us-central1-a"
+          },
+          "sensitive_values": {
+            "labels": {},
+            "licenses": [],
+            "snapshot_encryption_key": [],
+            "source_disk_encryption_key": [],
+            "storage_locations": [
+              false
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_disk.default",
+      "mode": "managed",
+      "type": "google_compute_disk",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "disk_encryption_key": [],
+          "image": "projects/debian-cloud/global/images/debian-8-jessie-v20170523",
+          "labels": null,
+          "name": "debian-disk",
+          "provisioned_iops": null,
+          "size": 10,
+          "snapshot": null,
+          "source_image_encryption_key": [],
+          "source_snapshot_encryption_key": [],
+          "timeouts": null,
+          "type": "pd-ssd",
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "creation_timestamp": true,
+          "disk_encryption_key": [],
+          "id": true,
+          "label_fingerprint": true,
+          "last_attach_timestamp": true,
+          "last_detach_timestamp": true,
+          "physical_block_size_bytes": true,
+          "project": true,
+          "self_link": true,
+          "source_image_encryption_key": [],
+          "source_image_id": true,
+          "source_snapshot_encryption_key": [],
+          "source_snapshot_id": true,
+          "users": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "disk_encryption_key": [],
+          "source_image_encryption_key": [],
+          "source_snapshot_encryption_key": [],
+          "users": []
+        }
+      }
+    },
+    {
+      "address": "google_compute_snapshot.default",
+      "mode": "managed",
+      "type": "google_compute_snapshot",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "description": null,
+          "labels": {
+            "test-name": "test-value"
+          },
+          "name": "test-instance",
+          "snapshot_encryption_key": [],
+          "source_disk": "debian-disk",
+          "source_disk_encryption_key": [],
+          "storage_locations": [
+            "us-central1"
+          ],
+          "timeouts": null,
+          "zone": "us-central1-a"
+        },
+        "after_unknown": {
+          "creation_timestamp": true,
+          "disk_size_gb": true,
+          "id": true,
+          "label_fingerprint": true,
+          "labels": {},
+          "licenses": true,
+          "project": true,
+          "self_link": true,
+          "snapshot_encryption_key": [],
+          "snapshot_id": true,
+          "source_disk_encryption_key": [],
+          "storage_bytes": true,
+          "storage_locations": [
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "labels": {},
+          "licenses": [],
+          "snapshot_encryption_key": [],
+          "source_disk_encryption_key": [],
+          "storage_locations": [
+            false
+          ]
+        }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": "{{.Provider.project}}"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_disk.default",
+          "mode": "managed",
+          "type": "google_compute_disk",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "image": {
+              "constant_value": "projects/debian-cloud/global/images/debian-8-jessie-v20170523"
+            },
+            "name": {
+              "constant_value": "debian-disk"
+            },
+            "size": {
+              "constant_value": 10
+            },
+            "type": {
+              "constant_value": "pd-ssd"
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "google_compute_snapshot.default",
+          "mode": "managed",
+          "type": "google_compute_snapshot",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "labels": {
+              "constant_value": {
+                "test-name": "test-value"
+              }
+            },
+            "name": {
+              "constant_value": "test-instance"
+            },
+            "source_disk": {
+              "references": [
+                "google_compute_disk.default.name",
+                "google_compute_disk.default"
+              ]
+            },
+            "storage_locations": {
+              "constant_value": [
+                "us-central1"
+              ]
+            },
+            "zone": {
+              "constant_value": "us-central1-a"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
magic module change is in https://github.com/GoogleCloudPlatform/magic-modules/pull/5451

Resolved https://github.com/GoogleCloudPlatform/terraform-validator/issues/227