### PR TITLE
Add support for google_compute_global_address 

### DIFF
--- a/converters/google/resources/resource_converters.go
+++ b/converters/google/resources/resource_converters.go
@@ -26,6 +26,7 @@ func ResourceConverters() map[string][]ResourceConverter {
 		"google_compute_firewall":                          {resourceConverterComputeFirewall()},
 		"google_compute_disk":                              {resourceConverterComputeDisk()},
 		"google_compute_forwarding_rule":                   {resourceConverterComputeForwardingRule()},
+		"google_compute_global_address":                    {resourceConverterComputeGlobalAddress()},
 		"google_compute_global_forwarding_rule":            {resourceConverterComputeGlobalForwardingRule()},
 		"google_compute_instance":                          {resourceConverterComputeInstance()},
 		"google_compute_network":                           {resourceConverterComputeNetwork()},

--- a/docs/supported_resources.md
+++ b/docs/supported_resources.md
@@ -29,6 +29,7 @@ google_compute_disk_iam_member                   | compute.googleapis.com/Disk
 google_compute_disk_iam_policy                   | compute.googleapis.com/Disk
 google_compute_firewall                          | compute.googleapis.com/Firewall
 google_compute_forwarding_rule                   | compute.googleapis.com/ForwardingRule
+google_compute_global_address                    | compute.googleapis.com/GlobalAddress
 google_compute_global_forwarding_rule            | compute.googleapis.com/GlobalForwardingRule
 google_compute_image_iam_binding                 | compute.googleapis.com/Image
 google_compute_image_iam_member                  | compute.googleapis.com/Image

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -76,6 +76,7 @@ func TestCLI(t *testing.T) {
 		{name: "example_compute_network"},
 		{name: "example_compute_snapshot"},
 		{name: "example_compute_subnetwork"},
+		{name: "example_compute_global_address"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},
 		{name: "example_dns_managed_zone"},

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -39,6 +39,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		{name: "example_compute_subnetwork"},
 		// This test can't run in offline mode.
 		// {name: "example_compute_forwarding_rule"},
+		{name: "example_compute_global_address"},
 		{name: "example_compute_global_forwarding_rule"},
 		{name: "example_container_cluster"},
 		{name: "example_dns_managed_zone"},

--- a/testdata/templates/example_compute_global_address.json
+++ b/testdata/templates/example_compute_global_address.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/addresses/global-appserver-ip",
+    "asset_type": "compute.googleapis.com/GlobalAddress",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "GlobalAddress",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "addressType": "EXTERNAL",
+        "name": "global-appserver-ip"
+      }
+    }
+  }
+]

--- a/testdata/templates/example_compute_global_address.tf
+++ b/testdata/templates/example_compute_global_address.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_global_address" "default" {
+  name = "global-appserver-ip"
+}

--- a/testdata/templates/example_compute_global_address.tfplan.json
+++ b/testdata/templates/example_compute_global_address.tfplan.json
@@ -1,0 +1,92 @@
+{
+  "format_version": "0.2",
+  "terraform_version": "1.0.10",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_global_address.default",
+          "mode": "managed",
+          "type": "google_compute_global_address",
+          "name": "default",
+          "provider_name": "registry.terraform.io/hashicorp/google",
+          "schema_version": 0,
+          "values": {
+            "address_type": null,
+            "description": null,
+            "ip_version": null,
+            "name": "global-appserver-ip",
+            "network": null,
+            "prefix_length": null,
+            "purpose": null,
+            "timeouts": null
+          },
+          "sensitive_values": {}
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "google_compute_global_address.default",
+      "mode": "managed",
+      "type": "google_compute_global_address",
+      "name": "default",
+      "provider_name": "registry.terraform.io/hashicorp/google",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "address_type": null,
+          "description": null,
+          "ip_version": null,
+          "name": "global-appserver-ip",
+          "network": null,
+          "prefix_length": null,
+          "purpose": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "address": true,
+          "creation_timestamp": true,
+          "id": true,
+          "project": true,
+          "self_link": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "google": {
+        "name": "google",
+        "expressions": {
+          "project": {
+            "constant_value": "{{.Provider.project}}"
+          }
+        }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "google_compute_global_address.default",
+          "mode": "managed",
+          "type": "google_compute_global_address",
+          "name": "default",
+          "provider_config_key": "google",
+          "expressions": {
+            "name": {
+              "constant_value": "global-appserver-ip"
+            }
+          },
+          "schema_version": 0
+        }
+      ]
+    }
+  }
+}

--- a/testdata/templates/full_sql_database_instance.json
+++ b/testdata/templates/full_sql_database_instance.json
@@ -31,13 +31,12 @@
         },
         "settings": {
           "activationPolicy": "test-activation_policy",
-
           "availabilityType": "REGIONAL",
           "backupConfiguration": {
             "binaryLogEnabled": true,
             "enabled": true,
-            "startTime": "42:42",
-            "location": "us"
+            "location": "us",
+            "startTime": "42:42"
           },
           "dataDiskSizeGb": "42",
           "dataDiskType": "test-disk_type",
@@ -83,6 +82,23 @@
             "user_labels_foo": "user_labels_bar"
           }
         }
+      }
+    }
+  },
+  {
+    "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/addresses/private-ip-address",
+    "asset_type": "compute.googleapis.com/GlobalAddress",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+    "resource": {
+      "version": "v1",
+      "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+      "discovery_name": "GlobalAddress",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+      "data": {
+        "addressType": "INTERNAL",
+        "name": "private-ip-address",
+        "prefixLength": 16,
+        "purpose": "VPC_PEERING"
       }
     }
   },


### PR DESCRIPTION
- Add a resource mapping for google_compute_global_address for issue https://github.com/GoogleCloudPlatform/terraform-validator/issues/225
- Upstream change is in https://github.com/GoogleCloudPlatform/magic-modules/pull/5475
- patch up full sql database instance generated json for the global address part. 
