### PR TITLE
Up version provider test version to 4.3.0

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -21,7 +21,7 @@ const (
 	defaultOrganization    = "12345"
 	defaultFolder          = "67890"
 	defaultProject         = "foobar"
-	defaultProviderVersion = "3.84.0"
+	defaultProviderVersion = "4.3.0"
 )
 
 var (

--- a/testdata/templates/example_dns_managed_zone.tfplan.json
+++ b/testdata/templates/example_dns_managed_zone.tfplan.json
@@ -95,7 +95,7 @@
 		"provider_config": {
 			"google": {
 				"name": "google",
-				"version_constraint": "~\u003e 3.84.0",
+				"version_constraint": "~\u003e 4.3.0",
 				"expressions": {
 					"project": {
 						"constant_value": "{{.Provider.project}}"

--- a/testdata/templates/example_sql_database_instance.json
+++ b/testdata/templates/example_sql_database_instance.json
@@ -14,6 +14,9 @@
         "project": "{{.Provider.project}}",
         "region": "us-central1",
         "settings": {
+          "activationPolicy": "ALWAYS",
+          "availabilityType": "ZONAL",
+          "dataDiskType": "PD_SSD",
           "pricingPlan": "PER_USE",
           "storageAutoResize": true,
           "tier": "db-f1-micro"

--- a/testdata/templates/example_sql_database_instance.tfplan.json
+++ b/testdata/templates/example_sql_database_instance.tfplan.json
@@ -21,9 +21,13 @@
             "root_password": null,
             "settings": [
               {
+                "activation_policy": "ALWAYS",
+                "availability_type": "ZONAL",
+                "collation": null,
                 "database_flags": [],
                 "disk_autoresize": true,
                 "disk_autoresize_limit": 0,
+                "disk_type": "PD_SSD",
                 "insights_config": [],
                 "maintenance_window": [],
                 "pricing_plan": "PER_USE",
@@ -31,6 +35,24 @@
               }
             ],
             "timeouts": null
+          },
+          "sensitive_values": {
+            "clone": [],
+            "ip_address": [],
+            "replica_configuration": [],
+            "restore_backup_context": [],
+            "server_ca_cert": [],
+            "settings": [
+              {
+                "backup_configuration": [],
+                "database_flags": [],
+                "insights_config": [],
+                "ip_configuration": [],
+                "location_preference": [],
+                "maintenance_window": [],
+                "user_labels": {}
+              }
+            ]
           }
         }
       ]
@@ -58,9 +80,13 @@
           "root_password": null,
           "settings": [
             {
+              "activation_policy": "ALWAYS",
+              "availability_type": "ZONAL",
+              "collation": null,
               "database_flags": [],
               "disk_autoresize": true,
               "disk_autoresize_limit": 0,
+              "disk_type": "PD_SSD",
               "insights_config": [],
               "maintenance_window": [],
               "pricing_plan": "PER_USE",
@@ -86,18 +112,35 @@
           "service_account_email_address": true,
           "settings": [
             {
-              "activation_policy": true,
-              "availability_type": true,
               "backup_configuration": true,
               "database_flags": [],
               "disk_size": true,
-              "disk_type": true,
               "insights_config": [],
               "ip_configuration": true,
               "location_preference": true,
               "maintenance_window": [],
               "user_labels": true,
               "version": true
+            }
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "clone": [],
+          "ip_address": [],
+          "replica_configuration": [],
+          "restore_backup_context": [],
+          "root_password": true,
+          "server_ca_cert": [],
+          "settings": [
+            {
+              "backup_configuration": [],
+              "database_flags": [],
+              "insights_config": [],
+              "ip_configuration": [],
+              "location_preference": [],
+              "maintenance_window": [],
+              "user_labels": {}
             }
           ]
         }

--- a/testdata/templates/full_compute_firewall.json
+++ b/testdata/templates/full_compute_firewall.json
@@ -34,7 +34,11 @@
         },
         "name": "test-firewall1",
         "network": "projects/{{.Provider.project}}/global/networks/test-network",
-        "priority": 42
+        "priority": 42,
+        "sourceServiceAccounts": [
+          "test-source_service_account2",
+          "test-source_service_account1"
+        ]
       }
     }
   },

--- a/testdata/templates/full_compute_firewall.tf
+++ b/testdata/templates/full_compute_firewall.tf
@@ -46,6 +46,7 @@ resource "google_compute_firewall" "full_list_default_1" {
   # Got: An argument named "enable_logging" is not expected here.
   # enable_logging = true
   priority = 42
+  source_service_accounts = ["test-source_service_account1", "test-source_service_account2"]
 }
 
 resource "google_compute_firewall" "full_list_default_2" {

--- a/testdata/templates/full_compute_firewall.tfplan.json
+++ b/testdata/templates/full_compute_firewall.tfplan.json
@@ -9,7 +9,7 @@
           "mode": "managed",
           "type": "google_compute_firewall",
           "name": "full_list_default_1",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 1,
           "values": {
             "allow": [
@@ -34,14 +34,43 @@
             ],
             "direction": "INGRESS",
             "disabled": true,
+            "log_config": [],
             "name": "test-firewall1",
             "network": "test-network",
             "priority": 42,
-            "source_service_accounts": null,
+            "source_ranges": null,
+            "source_service_accounts": [
+              "test-source_service_account1",
+              "test-source_service_account2"
+            ],
             "source_tags": null,
             "target_service_accounts": null,
             "target_tags": null,
             "timeouts": null
+          },
+          "sensitive_values": {
+            "allow": [
+              {
+                "ports": [
+                  false,
+                  false,
+                  false
+                ]
+              },
+              {
+                "ports": []
+              }
+            ],
+            "deny": [],
+            "destination_ranges": [
+              false,
+              false
+            ],
+            "log_config": [],
+            "source_service_accounts": [
+              false,
+              false
+            ]
           }
         },
         {
@@ -49,7 +78,7 @@
           "mode": "managed",
           "type": "google_compute_firewall",
           "name": "full_list_default_2",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 1,
           "values": {
             "allow": [],
@@ -69,6 +98,7 @@
             ],
             "description": null,
             "disabled": null,
+            "log_config": [],
             "name": "test-firewall2",
             "network": "test-network",
             "priority": 1000,
@@ -87,6 +117,35 @@
             ],
             "target_tags": null,
             "timeouts": null
+          },
+          "sensitive_values": {
+            "allow": [],
+            "deny": [
+              {
+                "ports": [
+                  false,
+                  false,
+                  false
+                ]
+              },
+              {
+                "ports": []
+              }
+            ],
+            "destination_ranges": [],
+            "log_config": [],
+            "source_ranges": [
+              false,
+              false
+            ],
+            "source_service_accounts": [
+              false,
+              false
+            ],
+            "target_service_accounts": [
+              false,
+              false
+            ]
           }
         },
         {
@@ -94,7 +153,7 @@
           "mode": "managed",
           "type": "google_compute_firewall",
           "name": "full_list_default_3",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 1,
           "values": {
             "allow": [],
@@ -106,9 +165,11 @@
             ],
             "description": null,
             "disabled": null,
+            "log_config": [],
             "name": "test-firewall3",
             "network": "test-network",
             "priority": 1000,
+            "source_ranges": null,
             "source_service_accounts": null,
             "source_tags": [
               "web"
@@ -119,6 +180,23 @@
               "test-target_tag2"
             ],
             "timeouts": null
+          },
+          "sensitive_values": {
+            "allow": [],
+            "deny": [
+              {
+                "ports": []
+              }
+            ],
+            "destination_ranges": [],
+            "log_config": [],
+            "source_tags": [
+              false
+            ],
+            "target_tags": [
+              false,
+              false
+            ]
           }
         },
         {
@@ -126,16 +204,16 @@
           "mode": "managed",
           "type": "google_compute_network",
           "name": "default",
-          "provider_name": "google",
+          "provider_name": "registry.terraform.io/hashicorp/google",
           "schema_version": 0,
           "values": {
             "auto_create_subnetworks": true,
             "delete_default_routes_on_create": false,
             "description": null,
-            "ipv4_range": null,
             "name": "test-network",
             "timeouts": null
-          }
+          },
+          "sensitive_values": {}
         }
       ]
     }
@@ -146,7 +224,7 @@
       "mode": "managed",
       "type": "google_compute_firewall",
       "name": "full_list_default_1",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -170,15 +248,20 @@
           "deny": [],
           "description": "test-description",
           "destination_ranges": [
-              "192.168.0.42/32",
-              "192.168.0.43/32"
+            "192.168.0.42/32",
+            "192.168.0.43/32"
           ],
           "direction": "INGRESS",
           "disabled": true,
+          "log_config": [],
           "name": "test-firewall1",
           "network": "test-network",
           "priority": 42,
-          "source_service_accounts": null,
+          "source_ranges": null,
+          "source_service_accounts": [
+            "test-source_service_account1",
+            "test-source_service_account2"
+          ],
           "source_tags": null,
           "target_service_accounts": null,
           "target_tags": null,
@@ -203,10 +286,40 @@
             false,
             false
           ],
+          "enable_logging": true,
           "id": true,
+          "log_config": [],
           "project": true,
           "self_link": true,
-          "source_ranges": true
+          "source_service_accounts": [
+            false,
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "allow": [
+            {
+              "ports": [
+                false,
+                false,
+                false
+              ]
+            },
+            {
+              "ports": []
+            }
+          ],
+          "deny": [],
+          "destination_ranges": [
+            false,
+            false
+          ],
+          "log_config": [],
+          "source_service_accounts": [
+            false,
+            false
+          ]
         }
       }
     },
@@ -215,7 +328,7 @@
       "mode": "managed",
       "type": "google_compute_firewall",
       "name": "full_list_default_2",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -239,6 +352,7 @@
           ],
           "description": null,
           "disabled": null,
+          "log_config": [],
           "name": "test-firewall2",
           "network": "test-network",
           "priority": 1000,
@@ -275,9 +389,41 @@
           ],
           "destination_ranges": true,
           "direction": true,
+          "enable_logging": true,
           "id": true,
+          "log_config": [],
           "project": true,
           "self_link": true,
+          "source_ranges": [
+            false,
+            false
+          ],
+          "source_service_accounts": [
+            false,
+            false
+          ],
+          "target_service_accounts": [
+            false,
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "allow": [],
+          "deny": [
+            {
+              "ports": [
+                false,
+                false,
+                false
+              ]
+            },
+            {
+              "ports": []
+            }
+          ],
+          "destination_ranges": [],
+          "log_config": [],
           "source_ranges": [
             false,
             false
@@ -298,7 +444,7 @@
       "mode": "managed",
       "type": "google_compute_firewall",
       "name": "full_list_default_3",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -314,9 +460,11 @@
           ],
           "description": null,
           "disabled": null,
+          "log_config": [],
           "name": "test-firewall3",
           "network": "test-network",
           "priority": 1000,
+          "source_ranges": null,
           "source_service_accounts": null,
           "source_tags": [
             "web"
@@ -338,10 +486,29 @@
           ],
           "destination_ranges": true,
           "direction": true,
+          "enable_logging": true,
           "id": true,
+          "log_config": [],
           "project": true,
           "self_link": true,
-          "source_ranges": true,
+          "source_tags": [
+            false
+          ],
+          "target_tags": [
+            false,
+            false
+          ]
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "allow": [],
+          "deny": [
+            {
+              "ports": []
+            }
+          ],
+          "destination_ranges": [],
+          "log_config": [],
           "source_tags": [
             false
           ],
@@ -357,7 +524,7 @@
       "mode": "managed",
       "type": "google_compute_network",
       "name": "default",
-      "provider_name": "google",
+      "provider_name": "registry.terraform.io/hashicorp/google",
       "change": {
         "actions": [
           "create"
@@ -367,31 +534,23 @@
           "auto_create_subnetworks": true,
           "delete_default_routes_on_create": false,
           "description": null,
-          "ipv4_range": null,
           "name": "test-network",
           "timeouts": null
         },
         "after_unknown": {
           "gateway_ipv4": true,
           "id": true,
+          "mtu": true,
           "project": true,
           "routing_mode": true,
           "self_link": true
-        }
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
       }
     }
   ],
   "configuration": {
-    "provider_config": {
-      "google": {
-        "name": "google",
-        "expressions": {
-          "project": {
-            "constant_value": "{{.Provider.project}}"
-          }
-        }
-      }
-    },
     "root_module": {
       "resources": [
         {
@@ -440,11 +599,18 @@
             },
             "network": {
               "references": [
+                "google_compute_network.default.name",
                 "google_compute_network.default"
               ]
             },
             "priority": {
               "constant_value": 42
+            },
+            "source_service_accounts": {
+              "constant_value": [
+                "test-source_service_account1",
+                "test-source_service_account2"
+              ]
             }
           },
           "schema_version": 1
@@ -480,6 +646,7 @@
             },
             "network": {
               "references": [
+                "google_compute_network.default.name",
                 "google_compute_network.default"
               ]
             },
@@ -523,6 +690,7 @@
             },
             "network": {
               "references": [
+                "google_compute_network.default.name",
                 "google_compute_network.default"
               ]
             },

--- a/testdata/templates/full_container_cluster.tf
+++ b/testdata/templates/full_container_cluster.tf
@@ -85,8 +85,6 @@ resource "google_container_cluster" "full_list_default_1" {
     }
   }
   master_auth {
-    username = "test-username"
-    password = "test-password"
     client_certificate_config {
       issue_client_certificate = true
     }

--- a/testdata/templates/full_container_cluster.tfplan.json
+++ b/testdata/templates/full_container_cluster.tfplan.json
@@ -1,6 +1,6 @@
 {
-  "format_version": "0.1",
-  "terraform_version": "0.13.6",
+  "format_version": "0.2",
+  "terraform_version": "1.0.10",
   "planned_values": {
     "root_module": {
       "resources": [
@@ -37,6 +37,7 @@
             "enable_binary_authorization": false,
             "enable_kubernetes_alpha": true,
             "enable_legacy_abac": true,
+            "enable_shielded_nodes": true,
             "enable_tpu": null,
             "initial_node_count": 42,
             "ip_allocation_policy": [
@@ -64,9 +65,7 @@
                   {
                     "issue_client_certificate": true
                   }
-                ],
-                "password": "test-password",
-                "username": "test-username"
+                ]
               }
             ],
             "master_authorized_networks_config": [
@@ -97,13 +96,16 @@
               {
                 "disk_size_gb": 42,
                 "disk_type": "pd-standard",
+                "gcfs_config": [],
                 "guest_accelerator": [
                   {
                     "count": 1,
+                    "gpu_partition_size": null,
                     "type": "test-type1"
                   },
                   {
                     "count": 1,
+                    "gpu_partition_size": null,
                     "type": "test-type2"
                   }
                 ],
@@ -132,7 +134,6 @@
               "test-node_locations"
             ],
             "node_version": "test-node_version",
-            "pod_security_policy_config": [],
             "private_cluster_config": [
               {
                 "enable_private_endpoint": true,
@@ -148,6 +149,94 @@
             "subnetwork": "test-subnetwork",
             "timeouts": null,
             "vertical_pod_autoscaling": []
+          },
+          "sensitive_values": {
+            "addons_config": [
+              {
+                "cloudrun_config": [],
+                "horizontal_pod_autoscaling": [
+                  {}
+                ],
+                "http_load_balancing": [
+                  {}
+                ],
+                "network_policy_config": [
+                  {}
+                ]
+              }
+            ],
+            "authenticator_groups_config": [],
+            "cluster_autoscaling": [],
+            "confidential_nodes": [],
+            "database_encryption": [],
+            "default_snat_status": [],
+            "ip_allocation_policy": [
+              {}
+            ],
+            "logging_config": [],
+            "maintenance_policy": [
+              {
+                "daily_maintenance_window": [
+                  {}
+                ],
+                "maintenance_exclusion": [],
+                "recurring_window": []
+              }
+            ],
+            "master_auth": [
+              {
+                "client_certificate_config": [
+                  {}
+                ]
+              }
+            ],
+            "master_authorized_networks_config": [
+              {
+                "cidr_blocks": [
+                  {},
+                  {}
+                ]
+              }
+            ],
+            "monitoring_config": [],
+            "network_policy": [
+              {}
+            ],
+            "node_config": [
+              {
+                "gcfs_config": [],
+                "guest_accelerator": [
+                  {},
+                  {}
+                ],
+                "labels": {},
+                "metadata": {},
+                "oauth_scopes": [
+                  false,
+                  false
+                ],
+                "shielded_instance_config": [],
+                "tags": [
+                  false
+                ],
+                "taint": [],
+                "workload_metadata_config": []
+              }
+            ],
+            "node_locations": [
+              false
+            ],
+            "node_pool": [],
+            "private_cluster_config": [
+              {
+                "master_global_access_config": []
+              }
+            ],
+            "release_channel": [],
+            "resource_labels": {},
+            "resource_usage_export_config": [],
+            "vertical_pod_autoscaling": [],
+            "workload_identity_config": []
           }
         }
       ]
@@ -191,6 +280,7 @@
           "enable_binary_authorization": false,
           "enable_kubernetes_alpha": true,
           "enable_legacy_abac": true,
+          "enable_shielded_nodes": true,
           "enable_tpu": null,
           "initial_node_count": 42,
           "ip_allocation_policy": [
@@ -218,9 +308,7 @@
                 {
                   "issue_client_certificate": true
                 }
-              ],
-              "password": "test-password",
-              "username": "test-username"
+              ]
             }
           ],
           "master_authorized_networks_config": [
@@ -251,13 +339,16 @@
             {
               "disk_size_gb": 42,
               "disk_type": "pd-standard",
+              "gcfs_config": [],
               "guest_accelerator": [
                 {
                   "count": 1,
+                  "gpu_partition_size": null,
                   "type": "test-type1"
                 },
                 {
                   "count": 1,
+                  "gpu_partition_size": null,
                   "type": "test-type2"
                 }
               ],
@@ -286,7 +377,6 @@
             "test-node_locations"
           ],
           "node_version": "test-node_version",
-          "pod_security_policy_config": [],
           "private_cluster_config": [
             {
               "enable_private_endpoint": true,
@@ -321,14 +411,13 @@
           "authenticator_groups_config": true,
           "cluster_autoscaling": true,
           "cluster_ipv4_cidr": true,
+          "confidential_nodes": true,
           "database_encryption": true,
           "datapath_provider": true,
           "default_snat_status": true,
           "enable_intranode_visibility": true,
-          "enable_shielded_nodes": true,
           "endpoint": true,
           "id": true,
-          "instance_group_urls": true,
           "ip_allocation_policy": [
             {
               "cluster_ipv4_cidr_block": true,
@@ -336,6 +425,7 @@
             }
           ],
           "label_fingerprint": true,
+          "logging_config": true,
           "maintenance_policy": [
             {
               "daily_maintenance_window": [
@@ -366,12 +456,14 @@
             }
           ],
           "master_version": true,
+          "monitoring_config": true,
           "network_policy": [
             {}
           ],
           "networking_mode": true,
           "node_config": [
             {
+              "gcfs_config": [],
               "guest_accelerator": [
                 {},
                 {}
@@ -395,7 +487,6 @@
           ],
           "node_pool": true,
           "operation": true,
-          "pod_security_policy_config": [],
           "private_cluster_config": [
             {
               "master_global_access_config": true,
@@ -414,6 +505,96 @@
           "tpu_ipv4_cidr_block": true,
           "vertical_pod_autoscaling": [],
           "workload_identity_config": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "addons_config": [
+            {
+              "cloudrun_config": [],
+              "horizontal_pod_autoscaling": [
+                {}
+              ],
+              "http_load_balancing": [
+                {}
+              ],
+              "network_policy_config": [
+                {}
+              ]
+            }
+          ],
+          "authenticator_groups_config": [],
+          "cluster_autoscaling": [],
+          "confidential_nodes": [],
+          "database_encryption": [],
+          "default_snat_status": [],
+          "ip_allocation_policy": [
+            {}
+          ],
+          "logging_config": [],
+          "maintenance_policy": [
+            {
+              "daily_maintenance_window": [
+                {}
+              ],
+              "maintenance_exclusion": [],
+              "recurring_window": []
+            }
+          ],
+          "master_auth": [
+            {
+              "client_certificate_config": [
+                {}
+              ],
+              "client_key": true
+            }
+          ],
+          "master_authorized_networks_config": [
+            {
+              "cidr_blocks": [
+                {},
+                {}
+              ]
+            }
+          ],
+          "monitoring_config": [],
+          "network_policy": [
+            {}
+          ],
+          "node_config": [
+            {
+              "gcfs_config": [],
+              "guest_accelerator": [
+                {},
+                {}
+              ],
+              "labels": {},
+              "metadata": {},
+              "oauth_scopes": [
+                false,
+                false
+              ],
+              "shielded_instance_config": [],
+              "tags": [
+                false
+              ],
+              "taint": [],
+              "workload_metadata_config": []
+            }
+          ],
+          "node_locations": [
+            false
+          ],
+          "node_pool": [],
+          "private_cluster_config": [
+            {
+              "master_global_access_config": []
+            }
+          ],
+          "release_channel": [],
+          "resource_labels": {},
+          "resource_usage_export_config": [],
+          "vertical_pod_autoscaling": [],
+          "workload_identity_config": []
         }
       }
     }
@@ -503,13 +684,7 @@
                       "constant_value": true
                     }
                   }
-                ],
-                "password": {
-                  "constant_value": "test-password"
-                },
-                "username": {
-                  "constant_value": "test-username"
-                }
+                ]
               }
             ],
             "master_authorized_networks_config": [

--- a/testdata/templates/sql.json
+++ b/testdata/templates/sql.json
@@ -14,6 +14,9 @@
         "project": "{{.Provider.project}}",
         "region": "us-central1",
         "settings": {
+          "activationPolicy": "ALWAYS",
+          "availabilityType": "ZONAL",
+          "dataDiskType": "PD_SSD",
           "pricingPlan": "PER_USE",
           "storageAutoResize": true,
           "tier": "db-f1-micro"


### PR DESCRIPTION
upstream change is in https://github.com/GoogleCloudPlatform/magic-modules/pull/5538. 
Including test data files here to validate the change. 