### PR TITLE
Changed behavior for 403 on IAM resources 

### DIFF
--- a/converters/google/resources/constants.go
+++ b/converters/google/resources/constants.go
@@ -15,9 +15,10 @@ var ErrNoConversion = errors.New("no conversion")
 // due to the identity field of that resource returning empty.
 var ErrEmptyIdentityField = errors.New("empty identity field")
 
-// ErrLackingReadPermissions can be returned when fetching a resource is not possible
-// due to the user not having read permissions.
-var ErrLackingReadPermission = errors.New("lacking read permissions")
+// ErrResourceInaccessible can be returned when fetching an IAM resource
+// on a project that has not yet been created or if the service account
+// lacks sufficient permissions
+var ErrResourceInaccessible = errors.New("resource does not exist or service account is lacking suffient permissions")
 
 // Global MutexKV
 var mutexKV = NewMutexKV()

--- a/converters/google/resources/iam_helpers.go
+++ b/converters/google/resources/iam_helpers.go
@@ -134,7 +134,7 @@ func mergeDeleteAdditiveBindings(existing, incoming []IAMBinding) []IAMBinding {
 		}
 		if newMembers != nil {
 			newExisting = append(newExisting, IAMBinding{
-				Role: binding.Role,
+				Role:    binding.Role,
 				Members: newMembers,
 			})
 		}
@@ -203,7 +203,7 @@ func fetchIamPolicy(
 
 	iamPolicy, err := updater.GetResourceIamPolicy()
 	if isGoogleApiErrorWithCode(err, 403) {
-		return Asset{}, ErrLackingReadPermission
+		return Asset{}, ErrResourceInaccessible
 	}
 
 	if err != nil {


### PR DESCRIPTION
Changed behavior for 403 on IAM resources to simply skip the asset. 

It's possible the resource has not been created yet so there is no way to differentiate permission from existance. 
closes https://github.com/GoogleCloudPlatform/terraform-validator/issues/393