### PR TITLE
don't use verbose flag for testing strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ run-docker:
 test-integration:
 	go version
 	terraform --version
-	go test -v -run=CLI ./test
+	go test -run=CLI ./test
 
 test-go-licenses:
 	cd .. && go version && go get github.com/google/go-licenses

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
-	"go.uber.org/zap"
 )
 
 func TestReadPlannedAssetsCoverage(t *testing.T) {
@@ -134,7 +134,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")
 			ctx := context.Background()
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false, zap.NewExample())
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false, zaptest.NewLogger(t))
 			if err != nil {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
 			}


### PR DESCRIPTION
For our testing strategy lets not use the verbose flag reduce output..

golang prints the output for failed tests anyways.