### PR TITLE
Made creation of test files only get printed with verbose logging or on failures

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -137,7 +137,7 @@ func generateTestFiles(t *testing.T, sourceDir string, targetDir string, selecto
 		if err := f.Close(); err != nil {
 			t.Fatalf("closing file %v: %v", path, err)
 		}
-		log.Printf("Successfully created file %v", path)
+		t.Logf("Successfully created file %v", path)
 	}
 }
 


### PR DESCRIPTION
I noticed this was incorrect while reviewing https://github.com/GoogleCloudPlatform/terraform-validator/pull/453 (always printing vs just on failure / verbose)