### PR TITLE
Log level after gcloud change

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -99,7 +99,7 @@ func newErrorLogger(verbosity string, useStructuredLogging bool, writeSyncer zap
 
 	encoderConfig := zapcore.EncoderConfig{
 		TimeKey:       "timestamp",
-		LevelKey:      "",
+		LevelKey:      "level",
 		MessageKey:    "",
 		StacktraceKey: "",
 		EncodeLevel:   zapcore.LowercaseLevelEncoder,
@@ -109,7 +109,6 @@ func newErrorLogger(verbosity string, useStructuredLogging bool, writeSyncer zap
 	if useStructuredLogging {
 		encoder = newJSONEncoder(encoderConfig)
 	} else {
-		encoderConfig.LevelKey = "level"
 		encoder = newConsoleEncoder(encoderConfig)
 	}
 	core := zapcore.NewCore(encoder, writeSyncer, level)

--- a/cmd/logger_test.go
+++ b/cmd/logger_test.go
@@ -56,6 +56,7 @@ func TestErrorLoggerSchema(t *testing.T) {
 	expectedOutput := map[string]interface{}{
 		"version":   "v1.0.0",
 		"timestamp": "tested separately",
+		"level":     "info",
 		"error_details": map[string]interface{}{
 			"error":   "This is a message",
 			"context": "",


### PR DESCRIPTION
This is to address https://github.com/GoogleCloudPlatform/terraform-validator/issues/372

gcloud need to be changed for structured output schema to accept log level first, else the schema validation complains about the new field. The change is released with version 368.0. 

Now that with the change, we can encode the level key in both structured logging and non structured logging. 

Tested with the latest release of gcloud 368.0 version, and tested with such a command 
```
$ gcloud alpha resource-config validate terraform /home/ciris/test-tf/tfplan.json --policy-library=~/test-tf/policy-library1 --verbosity info
```
- with the default terraform-validator binary (the one downloaded by gcloud)
```
ERROR: Error: [[INFO] Authenticating using configured Google JSON 'access_token'...].
ERROR: Error: [[INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]].
ERROR: Error: [[INFO] Authenticating using configured Google JSON 'access_token'...].
...
```
- with the compiled binary with this change,
```
ERROR: Info: [[INFO] Authenticating using configured Google JSON 'access_token'...].
ERROR: Info: [[INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]].
ERROR: Info: [[INFO] Authenticating using configured Google JSON 'access_token'...].
...
```

It shows with the change, it is able to resolve the log level. The starting `ERROR:` is prefixed by gcloud. 
