### PR TITLE
Add output option for convert 

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -16,11 +16,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 
-	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
+	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
+	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -29,7 +32,7 @@ import (
 
 const validateDesc = `
 Validate that a terraform plan conforms to a Constraint Framework
-policy library written to expect Google CAI (Cloud Asset Inventory) data. 
+policy library written to expect Google CAI (Cloud Asset Inventory) data.
 Unsupported terraform resources (see: "terraform-validate list-supported-resources")
 are skipped.
 
@@ -100,12 +103,22 @@ func (o *validateOptions) validateArgs(args []string) error {
 
 func (o *validateOptions) run(plan string) error {
 	ctx := context.Background()
-	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.rootOptions.errorLogger)
+
+	content, err := ioutil.ReadFile(plan)
 	if err != nil {
-		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
-			return errors.New("unable to parse provider project, please use --project flag")
+		return fmt.Errorf("unable to read file %s", plan)
+	}
+	// if input file is not Asset, try convert
+	var assets []google.Asset
+	if err := json.Unmarshal(content, &assets); err != nil {
+		var err error
+		assets, err = o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.rootOptions.errorLogger)
+		if err != nil {
+			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
+				return errors.New("unable to parse provider project, please use --project flag")
+			}
+			return errors.Wrap(err, "converting tfplan to CAI assets")
 		}
-		return errors.Wrap(err, "converting tfplan to CAI assets")
 	}
 
 	violations, err := o.validateAssets(ctx, assets, o.policyPath)


### PR DESCRIPTION
# Background
User perceived tfv stall because it takes long at validation. There proposed a solution to separate convert and validate for gcloud to execute them sequentially. For convert, it will stream the output, and for validate, it uses a progress tracker to show loading animation.
 

# PR
The plan is for convert command to write the result into a file, and validate command to take that file as the input. As a result, the PR does the following. 
- For convert subcommand, add output option. If that output option is not empty, write the converted content into a file. 
- For validate subcommand, support reading converted asset file 