### PR TITLE
Bumped dockerfile to golang 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 RUN apt-get update && apt-get -y install wget unzip
 


### PR DESCRIPTION
Using 1.14 is currently causing the image build to fail on the main branch.