### PR TITLE
Standardize user agent between ancestry manager and iam fetching & allow extension

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 
 	"github.com/spf13/cobra"
 )
@@ -39,6 +39,6 @@ func newVersionCmd() *cobra.Command {
 }
 
 func (o *versionOptions) run() error {
-	fmt.Printf("Build version: %s\n", tfgcv.BuildVersion())
+	fmt.Printf("Build version: %s\n", version.BuildVersion())
 	return nil
 }

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -33,10 +33,9 @@ const testProject = "test-project"
 func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	ctx := context.Background()
 	ancestry := "default-ancestry"
-	userAgent := ""
 	project := testProject
 	offline := true
-	cfg, err := resources.GetConfig(ctx, project, userAgent, offline)
+	cfg, err := resources.GetConfig(ctx, project, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing configuration")
 	}
@@ -44,7 +43,7 @@ func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	entries := map[string]string{
 		project: ancestry,
 	}
-	ancestryManager, err := ancestrymanager.New(cfg.NewResourceManagerClient(userAgent), entries, errorLogger)
+	ancestryManager, err := ancestrymanager.New(cfg.NewResourceManagerClient(cfg.UserAgent()), entries, errorLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource ancestryManager")
 	}

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -33,10 +33,10 @@ const testProject = "test-project"
 func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	ctx := context.Background()
 	ancestry := "default-ancestry"
-	ua := ""
+	userAgent := ""
 	project := testProject
 	offline := true
-	cfg, err := resources.GetConfig(ctx, project, offline)
+	cfg, err := resources.GetConfig(ctx, project, userAgent, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing configuration")
 	}
@@ -44,7 +44,7 @@ func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	entries := map[string]string{
 		project: ancestry,
 	}
-	ancestryManager, err := ancestrymanager.New(cfg, entries, ua, offline, errorLogger)
+	ancestryManager, err := ancestrymanager.New(cfg.NewResourceManagerClient(userAgent), entries, errorLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing resource ancestryManager")
 	}

--- a/converters/google/resources/getconfig.go
+++ b/converters/google/resources/getconfig.go
@@ -6,12 +6,19 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
 
-func GetConfig(ctx context.Context, project, userAgent string, offline bool) (*Config, error) {
+// Return the value of the private userAgent field
+func (c *Config) UserAgent() string {
+	return c.userAgent
+}
+
+func GetConfig(ctx context.Context, project string, offline bool) (*Config, error) {
 	cfg := &Config{
 		Project:   project,
-		userAgent: userAgent,
+		userAgent: fmt.Sprintf("config-validator-tf/%s", version.BuildVersion()),
 	}
 
 	// Search for default credentials

--- a/converters/google/resources/getconfig.go
+++ b/converters/google/resources/getconfig.go
@@ -2,13 +2,16 @@ package google
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 )
 
-func GetConfig(ctx context.Context, project string, offline bool) (*Config, error) {
+func GetConfig(ctx context.Context, project, userAgent string, offline bool) (*Config, error) {
 	cfg := &Config{
-		Project: project,
+		Project:   project,
+		userAgent: userAgent,
 	}
 
 	// Search for default credentials
@@ -25,6 +28,12 @@ func GetConfig(ctx context.Context, project string, offline bool) (*Config, erro
 	cfg.ImpersonateServiceAccount = multiEnvSearch([]string{
 		"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 	})
+
+	// opt in extension for adding to the User-Agent header
+	if ext := os.Getenv("GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION"); ext != "" {
+		ua := cfg.userAgent
+		cfg.userAgent = fmt.Sprintf("%s %s", ua, ext)
+	}
 
 	if !offline {
 		ConfigureBasePaths(cfg)

--- a/converters/google/resources/getconfig_test.go
+++ b/converters/google/resources/getconfig_test.go
@@ -19,6 +19,9 @@ func getAccessToken(cfg *Config) string {
 func getImpersonateServiceAccount(cfg *Config) string {
 	return cfg.ImpersonateServiceAccount
 }
+func getUserAgent(cfg *Config) string {
+	return cfg.UserAgent()
+}
 
 func TestGetConfigExtractsEnvVars(t *testing.T) {
 	ctx := context.Background()
@@ -27,37 +30,50 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 		name           string
 		envKey         string
 		envValue       string
+		expected       string
 		getConfigValue configAttrGetter
 	}{
 		{
 			name:           "GOOGLE_CREDENTIALS",
 			envKey:         "GOOGLE_CREDENTIALS",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GOOGLE_CLOUD_KEYFILE_JSON",
 			envKey:         "GOOGLE_CLOUD_KEYFILE_JSON",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GCLOUD_KEYFILE_JSON",
 			envKey:         "GCLOUD_KEYFILE_JSON",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getCredentials,
 		},
 		{
 			name:           "GOOGLE_OAUTH_ACCESS_TOKEN",
 			envKey:         "GOOGLE_OAUTH_ACCESS_TOKEN",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getAccessToken,
 		},
 		{
 			name:           "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 			envKey:         "GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 			envValue:       "whatever",
+			expected:       "whatever",
 			getConfigValue: getImpersonateServiceAccount,
+		},
+		{
+			name:           "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
+			envKey:         "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
+			envValue:       "whatever",
+			expected:       "config-validator-tf/dev whatever",
+			getConfigValue: getUserAgent,
 		},
 	}
 
@@ -69,12 +85,12 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 				t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
 			}
 
-			cfg, err := GetConfig(ctx, "project", "userAgent", offline)
+			cfg, err := GetConfig(ctx, "project", offline)
 			if err != nil {
 				t.Fatalf("error building converter: %s", err)
 			}
 
-			assert.EqualValues(t, c.getConfigValue(cfg), c.envValue)
+			assert.Equal(t, c.expected, c.getConfigValue(cfg))
 
 			if isSet {
 				err = os.Setenv(c.envKey, originalValue)

--- a/converters/google/resources/getconfig_test.go
+++ b/converters/google/resources/getconfig_test.go
@@ -69,7 +69,7 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 				t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
 			}
 
-			cfg, err := GetConfig(ctx, "project", offline)
+			cfg, err := GetConfig(ctx, "project", "userAgent", offline)
 			if err != nil {
 				t.Fatalf("error building converter: %s", err)
 			}

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -20,12 +20,16 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"google.golang.org/api/cloudresourcemanager/v1"
+
 	"github.com/GoogleCloudPlatform/terraform-validator/ancestrymanager"
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
 
 type ReadPlannedAssetsFunc func(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error)
@@ -62,15 +66,20 @@ func ReadPlannedAssets(ctx context.Context, path, project, ancestry string, offl
 }
 
 func newConverter(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) (*google.Converter, error) {
-	cfg, err := resources.GetConfig(ctx, project, offline)
+	userAgent := fmt.Sprintf("config-validator-tf/%s", version.BuildVersion())
+
+	cfg, err := resources.GetConfig(ctx, project, userAgent, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google configuration")
 	}
-	ua := fmt.Sprintf("config-validator-tf/%s", BuildVersion())
 	entries := map[string]string{
 		project: ancestry,
 	}
-	ancestryManager, err := ancestrymanager.New(cfg, entries, ua, offline, errorLogger)
+	var resourceManager *cloudresourcemanager.Service
+	if !offline {
+		resourceManager = cfg.NewResourceManagerClient(userAgent)
+	}
+	ancestryManager, err := ancestrymanager.New(resourceManager, entries, errorLogger)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google ancestry manager")
 	}

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -28,8 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-
-	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
 
 type ReadPlannedAssetsFunc func(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error)
@@ -66,9 +64,7 @@ func ReadPlannedAssets(ctx context.Context, path, project, ancestry string, offl
 }
 
 func newConverter(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) (*google.Converter, error) {
-	userAgent := fmt.Sprintf("config-validator-tf/%s", version.BuildVersion())
-
-	cfg, err := resources.GetConfig(ctx, project, userAgent, offline)
+	cfg, err := resources.GetConfig(ctx, project, offline)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google configuration")
 	}
@@ -77,7 +73,7 @@ func newConverter(ctx context.Context, path, project, ancestry string, offline, 
 	}
 	var resourceManager *cloudresourcemanager.Service
 	if !offline {
-		resourceManager = cfg.NewResourceManagerClient(userAgent)
+		resourceManager = cfg.NewResourceManagerClient(cfg.UserAgent())
 	}
 	ancestryManager, err := ancestrymanager.New(resourceManager, entries, errorLogger)
 	if err != nil {

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -18,19 +18,11 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
 	"github.com/GoogleCloudPlatform/config-validator/pkg/gcv"
+	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/pkg/errors"
 )
-
-// To be set by Go build tools.
-var buildVersion string
-
-// BuildVersion returns the build version of Terraform Validator.
-func BuildVersion() string {
-	return buildVersion
-}
 
 type ValidateAssetsFunc func(ctx context.Context, assets []google.Asset, policyRootPath string) ([]*validator.Violation, error)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+// To be set by Go build tools.
+var buildVersion string = "dev"
+
+// BuildVersion returns the build version of Terraform Validator.
+func BuildVersion() string {
+	return buildVersion
+}


### PR DESCRIPTION
This change lets us have a single source of truth for the user agent for TFV API calls, which can be extended similar to the terraform provider's user agent. b/214611094