### PR TITLE
Check policy lib path exists

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -123,7 +123,7 @@ func (o *validateOptions) run(plan string) error {
 
 	violations, err := o.validateAssets(ctx, assets, o.policyPath)
 	if err != nil {
-		return errors.Wrap(err, "validating: FCV")
+		return errors.Wrap(err, "validating")
 	}
 
 	if o.rootOptions.useStructuredLogging {

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -31,14 +31,19 @@ type ValidateAssetsFunc func(ctx context.Context, assets []google.Asset, policyR
 // ValidateAssets instantiates GCV and audits CAI assets using "policies"
 // and "lib" folder under policyRootPath.
 func ValidateAssets(ctx context.Context, assets []google.Asset, policyRootPath string) ([]*validator.Violation, error) {
-	policyLibPath := filepath.Join(policyRootPath, "policies", "lib")
-	_, err := os.Stat(policyLibPath)
+	policiesPath := filepath.Join(policyRootPath, "policies")
+	libPath := filepath.Join(policyRootPath, "lib")
+	_, err := os.Stat(policiesPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read files in %s", policyLibPath)
+		return nil, fmt.Errorf("failed to read files in %s", policiesPath)
+	}
+	_, err = os.Stat(libPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read files in %s", libPath)
 	}
 	return ValidateAssetsWithLibrary(ctx, assets,
-		[]string{filepath.Join(policyRootPath, "policies")},
-		filepath.Join(policyRootPath, "lib"))
+		[]string{policiesPath},
+		libPath)
 }
 
 // ValidateAssetsWithLibrary instantiates GCV and audits CAI assets.

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -16,6 +16,8 @@ package tfgcv
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
@@ -29,6 +31,11 @@ type ValidateAssetsFunc func(ctx context.Context, assets []google.Asset, policyR
 // ValidateAssets instantiates GCV and audits CAI assets using "policies"
 // and "lib" folder under policyRootPath.
 func ValidateAssets(ctx context.Context, assets []google.Asset, policyRootPath string) ([]*validator.Violation, error) {
+	policyLibPath := filepath.Join(policyRootPath, "policies", "lib")
+	_, err := os.Stat(policyLibPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read files in %s", policyLibPath)
+	}
 	return ValidateAssetsWithLibrary(ctx, assets,
 		[]string{filepath.Join(policyRootPath, "policies")},
 		filepath.Join(policyRootPath, "lib"))


### PR DESCRIPTION
b/203697534
Simplifying the error message when policy lib path is not readable. The config-validator library has too many layers of errors.Wrap, and removing all of them could possibly remove too much information for other error cases. 

Check both policies and lib path should exist. After the change, the message looks like this

```
// missing lib folder
ciris@ciris:~$ ~/gows/terraform-validator/bin/terraform-validator validate  test.json --policy-path=`pwd`/gows/policy-library/
2022-02-04T13:46:43.011040641-05:00	error	{"version": "v1.0.0", "error_details": {"error": "validating: failed to read files in /home/ciris/gows/policy-library/lib", "context": "github.com/GoogleCloudPlatform/terraform-validator/cmd.Execute\n\t/home/ciris/gows/terraform-validator/cmd/root.go:111\nmain.main\n\t/home/ciris/gows/terraform-validator/main.go:30\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}}

// missing policies folder
ciris@ciris:~$ ~/gows/terraform-validator/bin/terraform-validator validate  test.json --policy-path=`pwd`/gows/policy-library/
2022-02-04T13:47:45.789897059-05:00	error	{"version": "v1.0.0", "error_details": {"error": "validating: failed to read files in /home/ciris/gows/policy-library/policies", "context": "github.com/GoogleCloudPlatform/terraform-validator/cmd.Execute\n\t/home/ciris/gows/terraform-validator/cmd/root.go:111\nmain.main\n\t/home/ciris/gows/terraform-validator/main.go:30\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}}
```
