### PR TITLE
Change ancestry from string to map[string]string

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -93,7 +93,10 @@ func (o *convertOptions) validateArgs(args []string) error {
 
 func (o *convertOptions) run(plan string) error {
 	ctx := context.Background()
-	assets, err := o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.rootOptions.errorLogger)
+	ancestryCache := map[string]string{
+		o.project: o.ancestry,
+	}
+	assets, err := o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
 	if err != nil {
 		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 			return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -36,7 +36,7 @@ func testAssets() []google.Asset {
 	}
 }
 
-func MockReadPlannedAssets(ctx context.Context, path, project, ancestry string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
+func MockReadPlannedAssets(ctx context.Context, path, project string, ancestryCache map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
 	return testAssets(), nil
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -112,7 +112,10 @@ func (o *validateOptions) run(plan string) error {
 	var assets []google.Asset
 	if err := json.Unmarshal(content, &assets); err != nil {
 		var err error
-		assets, err = o.readPlannedAssets(ctx, plan, o.project, o.ancestry, o.offline, false, o.rootOptions.errorLogger)
+		ancestryCache := map[string]string{
+			o.project: o.ancestry,
+		}
+		assets, err = o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -138,9 +138,12 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")
 			ctx := context.Background()
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], data.Ancestry, true, false, zaptest.NewLogger(t))
+			ancestryCache := map[string]string{
+				data.Provider["project"]: data.Ancestry,
+			}
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t))
 			if err != nil {
-				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], data.Ancestry, true, err)
+				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], ancestryCache, true, err)
 			}
 
 			expectedAssets := normalizeAssets(t, want, true)

--- a/tfgcv/planned_assets_test.go
+++ b/tfgcv/planned_assets_test.go
@@ -2,9 +2,10 @@ package tfgcv
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"path/filepath"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 const (
@@ -77,7 +78,10 @@ func TestReadPlannedAssets(t *testing.T) {
 			var offline bool
 			offline = true
 			ctx := context.Background()
-			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, tt.args.ancestry, offline, tt.args.convertUnchanged, zap.NewExample())
+			ancestryCache := map[string]string{
+				tt.args.project: tt.args.ancestry,
+			}
+			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, ancestryCache, offline, tt.args.convertUnchanged, zap.NewExample())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReadPlannedAssets() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
b/211908063
Change function signatures to use map[string]string instead of a pure string for ancestry cache. This is to support folder ID as a key in the ancestry cache, rather than only project ID. 
This PR is to support a larger ancestry manager refactoring. 