### PR TITLE
Add an no-op ancestry manager

### DIFF
--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -178,3 +178,12 @@ func ancestryPath(as []*cloudresourcemanager.Ancestor) string {
 	}
 	return strings.Join(path, "/")
 }
+
+type NoOpAncestryManager struct{}
+
+func (m *NoOpAncestryManager) GetAncestry(project string) (string, error) {
+	return "", nil
+}
+func (m *NoOpAncestryManager) GetAncestryWithResource(project string, tfData resources.TerraformResourceData, cai resources.Asset) (string, error) {
+	return "", nil
+}

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -32,7 +32,6 @@ const testProject = "test-project"
 
 func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	ctx := context.Background()
-	ancestry := "default-ancestry"
 	project := testProject
 	offline := true
 	cfg, err := resources.GetConfig(ctx, project, offline)
@@ -40,14 +39,8 @@ func newTestConverter(convertUnchanged bool) (*Converter, error) {
 		return nil, errors.Wrap(err, "constructing configuration")
 	}
 	errorLogger := zap.NewExample()
-	entries := map[string]string{
-		project: ancestry,
-	}
-	ancestryManager, err := ancestrymanager.New(cfg.NewResourceManagerClient(cfg.UserAgent()), entries, errorLogger)
-	if err != nil {
-		return nil, errors.Wrap(err, "constructing resource ancestryManager")
-	}
-	c := NewConverter(cfg, ancestryManager, offline, convertUnchanged, errorLogger)
+	c := NewConverter(cfg, &ancestrymanager.NoOpAncestryManager{}, offline, convertUnchanged, errorLogger)
+
 	return c, nil
 }
 


### PR DESCRIPTION
Add an no op ancestry manager, so internal code can use this for testing, and no need to implement the ancestry manager interface. The interface will need to be modified. 