### PR TITLE
Add user agent parameter to ReadPlannedAssets()

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -17,9 +17,11 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -96,7 +98,8 @@ func (o *convertOptions) run(plan string) error {
 	ancestryCache := map[string]string{
 		o.project: o.ancestry,
 	}
-	assets, err := o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
+	userAgent := fmt.Sprintf("config-validator-tf/%s", version.BuildVersion())
+	assets, err := o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger, userAgent)
 	if err != nil {
 		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 			return errors.New("unable to parse provider project, please use --project flag")

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -36,7 +36,7 @@ func testAssets() []google.Asset {
 	}
 }
 
-func MockReadPlannedAssets(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
+func MockReadPlannedAssets(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger, userAgent string) ([]google.Asset, error) {
 	return testAssets(), nil
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
+	"github.com/GoogleCloudPlatform/terraform-validator/version"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -115,7 +116,8 @@ func (o *validateOptions) run(plan string) error {
 		ancestryCache := map[string]string{
 			o.project: o.ancestry,
 		}
-		assets, err = o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
+		userAgent := fmt.Sprintf("config-validator-tf/%s", version.BuildVersion())
+		assets, err = o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger, userAgent)
 		if err != nil {
 			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
 				return errors.New("unable to parse provider project, please use --project flag")

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -34,7 +34,7 @@ func newTestConverter(convertUnchanged bool) (*Converter, error) {
 	ctx := context.Background()
 	project := testProject
 	offline := true
-	cfg, err := resources.GetConfig(ctx, project, offline)
+	cfg, err := resources.GetConfig(ctx, project, offline, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing configuration")
 	}

--- a/converters/google/resources/getconfig.go
+++ b/converters/google/resources/getconfig.go
@@ -2,12 +2,8 @@ package google
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
-
-	"github.com/GoogleCloudPlatform/terraform-validator/version"
 )
 
 // Return the value of the private userAgent field
@@ -15,10 +11,10 @@ func (c *Config) UserAgent() string {
 	return c.userAgent
 }
 
-func GetConfig(ctx context.Context, project string, offline bool) (*Config, error) {
+func GetConfig(ctx context.Context, project string, offline bool, userAgent string) (*Config, error) {
 	cfg := &Config{
 		Project:   project,
-		userAgent: fmt.Sprintf("config-validator-tf/%s", version.BuildVersion()),
+		userAgent: userAgent,
 	}
 
 	// Search for default credentials
@@ -47,12 +43,6 @@ func GetConfig(ctx context.Context, project string, offline bool) (*Config, erro
 		"GCLOUD_REGION",
 		"CLOUDSDK_COMPUTE_REGION",
 	})
-
-	// opt in extension for adding to the User-Agent header
-	if ext := os.Getenv("GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION"); ext != "" {
-		ua := cfg.userAgent
-		cfg.userAgent = fmt.Sprintf("%s %s", ua, ext)
-	}
 
 	if !offline {
 		ConfigureBasePaths(cfg)

--- a/converters/google/resources/getconfig_test.go
+++ b/converters/google/resources/getconfig_test.go
@@ -116,13 +116,6 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 			expected:       "whatever",
 			getConfigValue: getRegionValue,
 		},
-		{
-			name:           "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
-			envKey:         "GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION",
-			envValue:       "whatever",
-			expected:       "config-validator-tf/dev whatever",
-			getConfigValue: getUserAgent,
-		},
 	}
 
 	for _, c := range cases {
@@ -133,7 +126,7 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 				t.Fatalf("error setting env var %s=%s: %s", c.envKey, c.envValue, err)
 			}
 
-			cfg, err := GetConfig(ctx, "project", offline)
+			cfg, err := GetConfig(ctx, "project", offline, "")
 			if err != nil {
 				t.Fatalf("error building converter: %s", err)
 			}
@@ -151,6 +144,35 @@ func TestGetConfigExtractsEnvVars(t *testing.T) {
 					t.Fatalf("error unsetting env var %s: %s", c.envKey, err)
 				}
 			}
+		})
+	}
+}
+
+func TestGetConfigUserAgent(t *testing.T) {
+	ctx := context.Background()
+	offline := true
+	cases := []struct {
+		userAgent string
+		expected  string
+	}{
+		{
+			userAgent: "",
+			expected:  "",
+		},
+		{
+			userAgent: "whatever",
+			expected:  "whatever",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.userAgent, func(t *testing.T) {
+			cfg, err := GetConfig(ctx, "project", offline, c.userAgent)
+			if err != nil {
+				t.Fatalf("error building converter: %s", err)
+			}
+
+			assert.Equal(t, c.expected, getUserAgent(cfg))
 		})
 	}
 }

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -143,7 +143,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 			ancestryCache := map[string]string{
 				data.Provider["project"]: data.Ancestry,
 			}
-			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t))
+			got, err := tfgcv.ReadPlannedAssets(ctx, planfile, data.Provider["project"], ancestryCache, true, false, zaptest.NewLogger(t), "")
 			if err != nil {
 				t.Fatalf("ReadPlannedAssets(%s, %s, %s, %t): %v", planfile, data.Provider["project"], ancestryCache, true, err)
 			}

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type ReadPlannedAssetsFunc func(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error)
+type ReadPlannedAssetsFunc func(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger, userAgent string) ([]google.Asset, error)
 
 // ReadPlannedAssets extracts CAI assets from a terraform plan file.
 // If ancestry path is provided, it assumes the project is in that path rather
@@ -39,8 +39,8 @@ type ReadPlannedAssetsFunc func(ctx context.Context, path, project string, ances
 // are also reported in the output, otherwise only resources that are going to
 // be changed are reported.
 // It ignores non-supported resources.
-func ReadPlannedAssets(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger) ([]google.Asset, error) {
-	converter, err := newConverter(ctx, path, project, ancestry, offline, convertUnchanged, errorLogger)
+func ReadPlannedAssets(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger, userAgent string) ([]google.Asset, error) {
+	converter, err := newConverter(ctx, path, project, ancestry, offline, convertUnchanged, errorLogger, userAgent)
 	if err != nil {
 		return nil, err
 	}
@@ -63,8 +63,8 @@ func ReadPlannedAssets(ctx context.Context, path, project string, ancestry map[s
 	return converter.Assets(), nil
 }
 
-func newConverter(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger) (*google.Converter, error) {
-	cfg, err := resources.GetConfig(ctx, project, offline)
+func newConverter(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger, userAgent string) (*google.Converter, error) {
+	cfg, err := resources.GetConfig(ctx, project, offline, userAgent)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google configuration")
 	}

--- a/tfgcv/planned_assets_test.go
+++ b/tfgcv/planned_assets_test.go
@@ -80,7 +80,7 @@ func TestReadPlannedAssets(t *testing.T) {
 			ancestryCache := map[string]string{
 				tt.args.project: tt.args.ancestry,
 			}
-			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, ancestryCache, offline, tt.args.convertUnchanged, zap.NewExample())
+			got, err := ReadPlannedAssets(ctx, testFile, tt.args.project, ancestryCache, offline, tt.args.convertUnchanged, zap.NewExample(), "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReadPlannedAssets() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This change allows other libraries to call `ReadPlannedAssets()` with an application-specific user-agent. The terraform-validator convert and validate commands will default to `config-validator-tf/*`.

Note that this also deprecates the usage of `GOOGLE_TERRAFORM_VALIDATOR_USERAGENT_EXTENSION` to append to the user-agent.