### PR TITLE
Added handling for more test vars to CI/CD

### DIFF
--- a/.ci/cloudbuild-tests-integration.yaml
+++ b/.ci/cloudbuild-tests-integration.yaml
@@ -22,6 +22,9 @@ steps:
   args: ['-c', 'mv /terraform/$_TERRAFORM_VERSION /bin/terraform && /usr/bin/make build && /usr/bin/make test-integration']
   env:
     - TEST_PROJECT=$_TEST_PROJECT
+    - TEST_FOLDER=$_TEST_FOLDER
+    - TEST_ANCESTRY=$_TEST_ANCESTRY
+    - TEST_ORG=$_TEST_ORG
     - TERRAFORM_VERSION=$_TERRAFORM_VERSION
 tags:
 - 'ci'

--- a/.ci/cloudbuild-tests-unit.yaml
+++ b/.ci/cloudbuild-tests-unit.yaml
@@ -25,7 +25,10 @@ steps:
   entrypoint: /usr/bin/make
   args: ['test']
   env:
-    - 'TEST_PROJECT=$_TEST_PROJECT'
+    - TEST_PROJECT=$_TEST_PROJECT
+    - TEST_FOLDER=$_TEST_FOLDER
+    - TEST_ANCESTRY=$_TEST_ANCESTRY
+    - TEST_ORG=$_TEST_ORG
     - 'GOPATH=/gopath'
   waitFor: ['build']
 tags:

--- a/testdata/templates/example_cloud_run_mapping.json
+++ b/testdata/templates/example_cloud_run_mapping.json
@@ -2,7 +2,7 @@
   {
     "name": "//run.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/DomainMappings/tf-test-domain-meep.gcp.tfacc.hashicorptest.com",
     "asset_type": "run.googleapis.com/DomainMapping",
-    "ancestry_path": "organization/{{.OrgID}}/folder/{{.FolderID}}/project/{{.Provider.project}}",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
     "resource": {
       "version": "v1",
       "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/run/v1/rest",
@@ -25,7 +25,7 @@
   {
     "name": "//run.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/services/tf-test-cloudrun-srv-beep",
     "asset_type": "run.googleapis.com/Service",
-    "ancestry_path": "organization/{{.OrgID}}/folder/{{.FolderID}}/project/{{.Provider.project}}",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
     "resource": {
       "version": "v1",
       "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/run/v1/rest",

--- a/testdata/templates/example_cloud_run_service.json
+++ b/testdata/templates/example_cloud_run_service.json
@@ -2,7 +2,7 @@
   {
     "name": "//run.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/services/cloudrun-to-get-cai",
     "asset_type": "run.googleapis.com/Service",
-    "ancestry_path": "organization/{{.OrgID}}/folder/{{.FolderID}}/project/{{.Provider.project}}",
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
     "resource": {
       "version": "v1",
       "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/run/v1/rest",

--- a/testdata/templates/example_project_organization_policy.json
+++ b/testdata/templates/example_project_organization_policy.json
@@ -23,6 +23,6 @@
         "update_time": "{{.Time.RFC3339Nano}}"
     }
     ],
-    "ancestry_path": "organization/{{.OrgID}}/folder/{{.FolderID}}/project/{{.Provider.project}}"
+    "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
   }
 ]


### PR DESCRIPTION
This is necessary to pass the test vars from the cloudbuild triggers to the test run.