### PR TITLE
Simplified converter error messages and added resource address

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -98,10 +98,7 @@ func (o *convertOptions) run(plan string) error {
 	}
 	assets, err := o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
 	if err != nil {
-		if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
-			return errors.New("unable to parse provider project, please use --project flag")
-		}
-		return errors.Wrap(err, "converting tfplan to CAI assets")
+		return err
 	}
 
 	if len(o.outputPath) > 0 {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -117,10 +117,7 @@ func (o *validateOptions) run(plan string) error {
 		}
 		assets, err = o.readPlannedAssets(ctx, plan, o.project, ancestryCache, o.offline, false, o.rootOptions.errorLogger)
 		if err != nil {
-			if errors.Cause(err) == tfgcv.ErrParsingProviderProject {
-				return errors.New("unable to parse provider project, please use --project flag")
-			}
-			return errors.Wrap(err, "converting tfplan to CAI assets")
+			return err
 		}
 	}
 

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -180,7 +180,7 @@ func (c *Converter) AddResourceChanges(changes []*tfjson.ResourceChange) error {
 
 		// Warn about google-beta resources
 		if rc.ProviderName == "registry.terraform.io/hashicorp/google-beta" {
-			c.errorLogger.Debug(fmt.Sprintf("%s: resource uses the google-beta provider and may not be convertable", rc.Address))
+			c.errorLogger.Debug(fmt.Sprintf("%s: resource uses the google-beta provider and may not be convertible", rc.Address))
 		}
 
 		// Skip resources not found in the google GA provider's schema

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -52,12 +52,12 @@ func ReadPlannedAssets(ctx context.Context, path, project string, ancestry map[s
 
 	changes, err := tfplan.ReadResourceChanges(data)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading resource changes")
+		return nil, err
 	}
 
 	err = converter.AddResourceChanges(changes)
 	if err != nil {
-		return nil, errors.Wrap(err, "adding resource changes to converter")
+		return nil, err
 	}
 
 	return converter.Assets(), nil
@@ -92,5 +92,3 @@ func readTF12Data(path string) ([]byte, error) {
 	}
 	return data, nil
 }
-
-var ErrParsingProviderProject = errors.New("unable to parse provider project")


### PR DESCRIPTION
Goals:

- Reduce technical jargon so that errors are easier to understand
- Add resource address to all error messages so that large plans are easier to debug.
- Don't log anything related to non-google resources
- Reduce level of messages that don't impact normal operations
- Add debug-level warnings if there is a beta resource in the plan

b/225383221