### PR TITLE
Add ancestors into Asset

### DIFF
--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -40,7 +40,6 @@ var ErrDuplicateAsset = errors.New("duplicate asset")
 type Asset struct {
 	Name      string         `json:"name"`
 	Type      string         `json:"asset_type"`
-	Ancestry  string         `json:"ancestry_path"`
 	Resource  *AssetResource `json:"resource,omitempty"`
 	IAMPolicy *IAMPolicy     `json:"iam_policy,omitempty"`
 	OrgPolicy []*OrgPolicy   `json:"org_policy,omitempty"`
@@ -425,7 +424,6 @@ func (c *Converter) augmentAsset(tfData resources.TerraformResourceData, cfg *re
 	return Asset{
 		Name:           cai.Name,
 		Type:           cai.Type,
-		Ancestry:       ancestrymanager.ConvertToAncestryPath(ancestors),
 		Resource:       resource,
 		IAMPolicy:      policy,
 		OrgPolicy:      orgPolicy,

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -48,6 +48,7 @@ type Asset struct {
 	// operate on this type. When matching json tags land in the conversions
 	// library, this could be nested to avoid the duplication of fields.
 	converterAsset resources.Asset
+	Ancestors      []string `json:"ancestors"`
 }
 
 // IAMPolicy is the representation of a Cloud IAM policy set on a cloud resource.
@@ -429,5 +430,6 @@ func (c *Converter) augmentAsset(tfData resources.TerraformResourceData, cfg *re
 		IAMPolicy:      policy,
 		OrgPolicy:      orgPolicy,
 		converterAsset: cai,
+		Ancestors:      ancestors,
 	}, nil
 }

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"encoding/json"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfgcv"
 	"go.uber.org/zap/zaptest"
 )
@@ -129,20 +127,9 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 
 			// Unmarshal payload from testfile into `want` variable.
 			f := filepath.Join(dir, c.name+".json")
-			payload, err := ioutil.ReadFile(f)
+			want, err := readExpectedTestFile(f)
 			if err != nil {
-				t.Fatalf("cannot open %s, got: %s", f, err)
-			}
-			var want []google.Asset
-			if err := json.Unmarshal(payload, &want); err != nil {
-				t.Fatalf("cannot unmarshal JSON into assets: %s", err)
-			}
-			for ix := range want {
-				ancestors, err := ancestryPathToAncestors(want[ix].Ancestry)
-				if err != nil {
-					t.Fatalf("failed to convert to ancestors: %s", err)
-				}
-				want[ix].Ancestors = ancestors
+				t.Fatal(err)
 			}
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")

--- a/test/read_test.go
+++ b/test/read_test.go
@@ -21,7 +21,7 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 		name string
 	}{
 		// read-only, the following tests are not in cli_test or
-		// have unique paramters that separate them
+		// have unique parameters that separate them
 		{name: "example_project_create"},
 		{name: "example_project_update"},
 		{name: "example_project_iam_binding"},
@@ -136,6 +136,13 @@ func TestReadPlannedAssetsCoverage(t *testing.T) {
 			var want []google.Asset
 			if err := json.Unmarshal(payload, &want); err != nil {
 				t.Fatalf("cannot unmarshal JSON into assets: %s", err)
+			}
+			for ix := range want {
+				ancestors, err := ancestryPathToAncestors(want[ix].Ancestry)
+				if err != nil {
+					t.Fatalf("failed to convert to ancestors: %s", err)
+				}
+				want[ix].Ancestors = ancestors
 			}
 
 			planfile := filepath.Join(dir, c.name+".tfplan.json")

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -30,22 +29,9 @@ func testConvertCommand(t *testing.T, dir, name string, offline bool, compare co
 	}
 
 	// Load expected assets
-	var expectedRaw []byte
-	testfile := filepath.Join(dir, name+".json")
-	expectedRaw, err := ioutil.ReadFile(testfile)
+	expected, err := readExpectedTestFile(filepath.Join(dir, name+".json"))
 	if err != nil {
-		t.Fatalf("Error reading %v: %v", testfile, err)
-	}
-	var expected []google.Asset
-	if err := json.Unmarshal(expectedRaw, &expected); err != nil {
-		t.Fatalf("unmarshaling: %v", err)
-	}
-	for ix := range expected {
-		ancestors, err := ancestryPathToAncestors(expected[ix].Ancestry)
-		if err != nil {
-			t.Fatalf("failed to convert to ancestors: %s", err)
-		}
-		expected[ix].Ancestors = ancestors
+		t.Fatal(err)
 	}
 
 	// Get converted assets

--- a/test/utils_test.go
+++ b/test/utils_test.go
@@ -40,6 +40,13 @@ func testConvertCommand(t *testing.T, dir, name string, offline bool, compare co
 	if err := json.Unmarshal(expectedRaw, &expected); err != nil {
 		t.Fatalf("unmarshaling: %v", err)
 	}
+	for ix := range expected {
+		ancestors, err := ancestryPathToAncestors(expected[ix].Ancestry)
+		if err != nil {
+			t.Fatalf("failed to convert to ancestors: %s", err)
+		}
+		expected[ix].Ancestors = ancestors
+	}
 
 	// Get converted assets
 	var actualRaw []byte

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -21,7 +21,9 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
+	cvasset "github.com/GoogleCloudPlatform/config-validator/pkg/asset"
 	"github.com/GoogleCloudPlatform/config-validator/pkg/gcv"
+
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
 	"github.com/pkg/errors"
 )
@@ -67,6 +69,11 @@ func ValidateAssetsWithLibrary(ctx context.Context, assets []google.Asset, polic
 	// can be properly serialized to JSON.
 	violations := []*validator.Violation{}
 	for _, asset := range pbSplitAssets {
+		err := cvasset.SanitizeAncestryPath(asset)
+		if err != nil {
+			return nil, errors.Wrapf(err, "SanitizeAncestryPath %s", asset)
+		}
+
 		newViolations, err := valid.ReviewAsset(context.Background(), asset)
 
 		if err != nil {


### PR DESCRIPTION
- https://github.com/GoogleCloudPlatform/terraform-validator/issues/105
- changes required in magic module: https://github.com/GoogleCloudPlatform/magic-modules/pull/6091

Adding ancestors into Asset, and update test comparison logic to derive ancestors from ancestry path for the expected object. Test files will be overwritten by the magic module PR. 

