### PR TITLE
clean up validate code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/GoogleCloudPlatform/terraform-validator
 
 require (
 	cloud.google.com/go/bigtable v1.13.0
-	github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601172935-268f307cad62
+	github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601215952-9c7f9463df8c
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601172935-268f307cad62 h1:Zj9fUqSqcVfRgQYLWvG/2ftHBp/W9uxOZPqsYQ/+U5M=
-github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601172935-268f307cad62/go.mod h1:1tEOIczCu1Pfe0ApnRfQB0NqTVsu3RoyFl6s8uz1LUg=
+github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601215952-9c7f9463df8c h1:G7DGGKmni0CTZqaD9Hdkzzb0hy95qQx2jHYH+KulUxE=
+github.com/GoogleCloudPlatform/config-validator v0.0.0-20220601215952-9c7f9463df8c/go.mod h1:1tEOIczCu1Pfe0ApnRfQB0NqTVsu3RoyFl6s8uz1LUg=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.8.2 h1:V2EzqYSMPUkyKTtSevKTFU0Dw7nK6uVpg40U31Y0x/8=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.8.2/go.mod h1:UJoDYx6t3+xCOd+dZX8+NrEB+Y/eW1pQlvxh2Gt7y5E=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/tfgcv/validate_assets.go
+++ b/tfgcv/validate_assets.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleCloudPlatform/config-validator/pkg/api/validator"
-	cvasset "github.com/GoogleCloudPlatform/config-validator/pkg/asset"
 	"github.com/GoogleCloudPlatform/config-validator/pkg/gcv"
 
 	"github.com/GoogleCloudPlatform/terraform-validator/converters/google"
@@ -69,11 +68,6 @@ func ValidateAssetsWithLibrary(ctx context.Context, assets []google.Asset, polic
 	// can be properly serialized to JSON.
 	violations := []*validator.Violation{}
 	for _, asset := range pbSplitAssets {
-		err := cvasset.SanitizeAncestryPath(asset)
-		if err != nil {
-			return nil, errors.Wrapf(err, "SanitizeAncestryPath %s", asset)
-		}
-
 		newViolations, err := valid.ReviewAsset(context.Background(), asset)
 
 		if err != nil {


### PR DESCRIPTION
Remove sanitize ancestry path, since it is already fixed in config-validator. 