### PR TITLE
Removed non-generated usage of GetConfig

### DIFF
--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -62,7 +62,7 @@ func newTestConverter(convertUnchanged bool) (*Converter, *bytes.Buffer, error) 
 	ctx := context.Background()
 	project := testProject
 	offline := true
-	cfg, err := resources.GetConfig(ctx, project, offline, "")
+	cfg, err := resources.NewConfig(ctx, project, offline, "", nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "constructing configuration")
 	}

--- a/tfgcv/planned_assets.go
+++ b/tfgcv/planned_assets.go
@@ -64,7 +64,7 @@ func ReadPlannedAssets(ctx context.Context, path, project string, ancestry map[s
 }
 
 func newConverter(ctx context.Context, path, project string, ancestry map[string]string, offline, convertUnchanged bool, errorLogger *zap.Logger, userAgent string) (*google.Converter, error) {
-	cfg, err := resources.GetConfig(ctx, project, offline, userAgent)
+	cfg, err := resources.NewConfig(ctx, project, offline, userAgent, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "building google configuration")
 	}


### PR DESCRIPTION
NewConfig better matches Go naming best practices. Changing this usage in non-generated files will allow removal of GetConfig from the upstream.