### PR TITLE
Set timeout for cloudbuild-image job to 20 minutes because it times out regularly after 10

### DIFF
--- a/.ci/cloudbuild-image.yaml
+++ b/.ci/cloudbuild-image.yaml
@@ -5,3 +5,5 @@ steps:
   args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/terraform-validator', '.' ]
 images:
   - gcr.io/$PROJECT_ID/terraform-validator
+timeout:
+  - 1200s # 20 minutes


### PR DESCRIPTION
https://console.cloud.google.com/cloud-build/builds?project=config-validator&pageState=(%22builds%22:(%22f%22:%22%255B%257B_22k_22_3A_22Trigger%2520Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22terraform-validator-image_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22triggerName_22%257D%255D%22))