### PR TITLE
Changes to ancestrymanager logic to parse "parent" field for project, folder and organization asset types.

### DIFF
--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -146,10 +146,13 @@ func (m *manager) fetchAncestors(config *resources.Config, tfData resources.Terr
 
 	switch cai.Type {
 	case "cloudresourcemanager.googleapis.com/Folder":
-		if !folderOK {
+		if folderOK {
+			key = folderKey
+		} else if orgOK {
+			key = orgKey
+		} else {
 			return []string{"organizations/unknown"}, nil
 		}
-		key = folderKey
 	case "cloudresourcemanager.googleapis.com/Organization":
 		if !orgOK {
 			return nil, fmt.Errorf("organization id not found in terraform data")

--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -324,6 +324,12 @@ func (m *manager) getProjectFromResource(d resources.TerraformResourceData, conf
 		if ok {
 			return res.(string), nil
 		}
+		
+		res, ok = d.GetOk("parent")
+		if ok && strings.HasPrefix(res.(string), "projects/"){
+			return res.(string), nil
+		}
+
 		// Fall back to project_id if number is not available.
 		res, ok = d.GetOk("project_id")
 		if ok {

--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -327,12 +327,7 @@ func (m *manager) getProjectFromResource(d resources.TerraformResourceData, conf
 		if ok {
 			return res.(string), nil
 		}
-
-		res, ok = d.GetOk("parent")
-		if ok && strings.HasPrefix(res.(string), "projects/") {
-			return res.(string), nil
-		}
-
+		
 		// Fall back to project_id if number is not available.
 		res, ok = d.GetOk("project_id")
 		if ok {

--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -1,133 +1,372 @@
+// Package ancestrymanager provides an interface to query the ancestry information for a resource.
 package ancestrymanager
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
+	crmv1 "google.golang.org/api/cloudresourcemanager/v1"
+	crmv3 "google.golang.org/api/cloudresourcemanager/v3"
+	"google.golang.org/api/storage/v1"
+
 	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
-	"github.com/hashicorp/errwrap"
-	"google.golang.org/api/googleapi"
+
+	"go.uber.org/zap"
 )
 
-// assetParent derives a resource's parent from its ancestors.
-func assetParent(cai *resources.Asset, ancestors []string) (string, error) {
-	if cai == nil {
-		return "", fmt.Errorf("asset not provided")
+// AncestryManager is the interface that fetch ancestors for a resource.
+type AncestryManager interface {
+	// Ancestors returns a list of ancestors.
+	Ancestors(config *resources.Config, tfData resources.TerraformResourceData, cai *resources.Asset) ([]string, string, error)
+}
+
+type manager struct {
+	// The logger.
+	errorLogger *zap.Logger
+	// cloud resource manager V3 client. If this field is nil, online lookups will
+	// be disabled.
+	// cloud resource manager V1 client. If this field is nil, online lookups will
+	// be disabled.
+	resourceManagerV3 *crmv3.Service
+	resourceManagerV1 *crmv1.Service
+	storageClient     *storage.Service
+	// Cache to prevent multiple network calls for looking up the same
+	// resource's ancestry. The map key is the resource itself, in the format of
+	// "<type>/<id>", ancestors are sorted from closest to furthest.
+	ancestorCache map[string][]string
+}
+
+// New returns AncestryManager that can be used to fetch ancestry information.
+// Entries takes `projects/<number>` or `folders/<id>` as key and ancestry path
+// as value to the offline cache. If the key is not prefix with `projects/` or
+// `folders/`, it will be considered as a project. If offline is true, resource
+// manager API requests for ancestry will be disabled.
+func New(cfg *resources.Config, offline bool, entries map[string]string, errorLogger *zap.Logger) (AncestryManager, error) {
+	am := &manager{
+		ancestorCache: map[string][]string{},
+		errorLogger:   errorLogger,
 	}
+	if !offline {
+		am.resourceManagerV1 = cfg.NewResourceManagerClient(cfg.GetUserAgent())
+		am.resourceManagerV3 = cfg.NewResourceManagerV3Client(cfg.GetUserAgent())
+		am.storageClient = cfg.NewStorageClient(cfg.GetUserAgent())
+	}
+	err := am.initAncestryCache(entries)
+	if err != nil {
+		return nil, err
+	}
+	return am, nil
+}
+
+func (m *manager) initAncestryCache(entries map[string]string) error {
+	for item, ancestry := range entries {
+		if item != "" && ancestry != "" {
+			ancestors, err := parseAncestryPath(ancestry)
+			if err != nil {
+				continue
+			}
+			key, err := parseAncestryKey(item)
+			if err != nil {
+				return err
+			}
+			// ancestry path should include the item itself
+			if ancestors[0] != key {
+				ancestors = append([]string{key}, ancestors...)
+			}
+			m.store(key, ancestors)
+		}
+	}
+	return nil
+}
+
+func parseAncestryKey(val string) (string, error) {
+	key := normalizeAncestry(val)
+	ix := strings.LastIndex(key, "/")
+	if ix == -1 {
+		// If not containing /, then treat it as a project.
+		return fmt.Sprintf("projects/%s", key), nil
+	} else {
+		k := key[:ix]
+		if k == "projects" || k == "folders" || k == "organizations" {
+			return key, nil
+		}
+		return "", fmt.Errorf("key with can only start with projects/, folders/, or organizations/")
+	}
+}
+
+// Ancestors uses the resource manager API to get ancestors for resource.
+// It implements a cache because many resources share the same ancestors.
+func (m *manager) Ancestors(config *resources.Config, tfData resources.TerraformResourceData, cai *resources.Asset) ([]string, string, error) {
+	results, err := m.fetchAncestors(config, tfData, cai)
+	if err != nil {
+		return nil, "", err
+	}
+
+	parent, err := assetParent(cai, results)
+	if err != nil {
+		return nil, "", err
+	}
+	return results, parent, nil
+}
+
+// fetchAncestors uses the resource manager API to get ancestors for resource.
+// It implements a cache because many resources share the same ancestors.
+func (m *manager) fetchAncestors(config *resources.Config, tfData resources.TerraformResourceData, cai *resources.Asset) ([]string, error) {
+	if cai == nil {
+		return nil, fmt.Errorf("CAI asset is nil")
+	}
+	m.errorLogger.Info(fmt.Sprintf("Retrieving ancestry from resource (type=%s)", cai.Type))
+	key := ""
+	orgKey := ""
+	folderKey := ""
+	projectKey := ""
+
+	orgID, orgOK := getOrganizationFromResource(tfData)
+	if orgOK {
+		orgKey = orgID
+		if !strings.HasPrefix(orgKey, "organizations/") {
+			orgKey = fmt.Sprintf("organizations/%s", orgKey)
+		}
+	}
+	folderID, folderOK := getFolderFromResource(tfData)
+	if folderOK {
+		folderKey = folderID
+		if !strings.HasPrefix(folderKey, "folders/") {
+			folderKey = fmt.Sprintf("folders/%s", folderKey)
+		}
+	}
+	project, _ := m.getProjectFromResource(tfData, config, cai)
+	if project != "" {
+		projectKey = project
+		if !strings.HasPrefix(projectKey, "projects/") {
+			projectKey = fmt.Sprintf("projects/%s", project)
+		}
+	}
+
 	switch cai.Type {
 	case "cloudresourcemanager.googleapis.com/Folder":
-		if len(ancestors) > 1 {
-			parent := ancestors[1]
-			if strings.HasPrefix(parent, "folders/") || strings.HasPrefix(parent, "organizations/") {
-				return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[1]), nil
-			}
-		}
-		if len(ancestors) == 1 && strings.HasPrefix(ancestors[0], "organizations/") {
-			// organizations/unknown
-			return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[0]), nil
+		if folderOK {
+			key = folderKey
+		} else if orgOK {
+			key = orgKey
+		} else {
+			return []string{"organizations/unknown"}, nil
 		}
 	case "cloudresourcemanager.googleapis.com/Organization":
-		return "", nil
-	case "cloudresourcemanager.googleapis.com/Project":
-		if len(ancestors) < 1 {
-			return "", fmt.Errorf("unexpected value for ancestors: %s", ancestors)
+		if !orgOK {
+			return nil, fmt.Errorf("organization id not found in terraform data")
 		}
-		if strings.HasPrefix(ancestors[0], "projects/") {
-			if len(ancestors) > 1 {
-				return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[1]), nil
+		key = orgKey
+	case "iam.googleapis.com/Role":
+		// google_organization_iam_custom_role or google_project_iam_custom_role
+		if orgOK {
+			key = orgKey
+		} else if projectKey != "" {
+			key = projectKey
+		} else {
+			return []string{"organizations/unknown"}, nil
+		}
+	case "cloudresourcemanager.googleapis.com/Project", "cloudbilling.googleapis.com/ProjectBillingInfo":
+		// for google_project and google_project_iam resources
+		var ancestors []string
+		if projectKey != "" {
+			ancestors = []string{projectKey}
+			// Get ancestry from project level with v1 API first.
+			// This is to avoid requiring folder level permission if
+			// there is no folder change.
+			m.getAncestorsWithCache(projectKey)
+		}
+		// only folder_id or org_id is allowed for google_project
+		if orgOK {
+			// no need to use API to fetch ancestors
+			ancestors = append(ancestors, fmt.Sprintf("organizations/%s", orgID))
+			return ancestors, nil
+		}
+		if folderOK {
+			// If folder is changed, then it goes with v3 API, else it will use cache.
+			key = folderKey
+			ret, err := m.getAncestorsWithCache(key)
+			if err != nil {
+				return nil, err
 			}
+			ancestors = append(ancestors, ret...)
+			return ancestors, nil
 		}
-		return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[0]), nil
+
+		// neither folder_id nor org_id is specified
+		if projectKey == "" {
+			return []string{"organizations/unknown"}, nil
+		}
+		key = projectKey
+
 	default:
-		if len(ancestors) < 1 {
-			return "", fmt.Errorf("unexpected value for ancestors: %s", ancestors)
+		if projectKey == "" {
+			return []string{"organizations/unknown"}, nil
 		}
-		return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[0]), nil
+		key = projectKey
 	}
-	return "", fmt.Errorf("unexpected value for ancestors: %v", ancestors)
+	return m.getAncestorsWithCache(key)
 }
 
-// ConvertToAncestryPath composes a path containing organization/folder/project
-// (i.e. "organization/my-org/folder/my-folder/project/my-prj").
-func ConvertToAncestryPath(as []string) string {
-	var path []string
-	for i := len(as) - 1; i >= 0; i-- {
-		path = append(path, as[i])
+func (m *manager) getAncestorsWithCache(key string) ([]string, error) {
+	var ancestors []string
+	cur := key
+	for cur != "" {
+		if cachedAncestors, ok := m.ancestorCache[cur]; ok {
+			ancestors = append(ancestors, cachedAncestors...)
+			break
+		}
+		if strings.HasPrefix(cur, "organizations/") {
+			ancestors = append(ancestors, cur)
+			break
+		}
+		if m.resourceManagerV3 == nil || m.resourceManagerV1 == nil {
+			return nil, fmt.Errorf("resourceManager required to fetch ancestry for %s from the API", cur)
+		}
+		if strings.HasPrefix(cur, "projects") {
+			// fall back to use v1 API GetAncestry to avoid requiring extra folder permission
+			projectID := strings.TrimPrefix(cur, "projects/")
+			resp, err := m.resourceManagerV1.Projects.GetAncestry(projectID, &crmv1.GetAncestryRequest{}).Do()
+			if err != nil {
+				return nil, handleCRMError(cur, err)
+			}
+			for _, anc := range resp.Ancestor {
+				ancestor := normalizeAncestry(fmt.Sprintf("%s/%s", anc.ResourceId.Type, anc.ResourceId.Id))
+				ancestors = append(ancestors, ancestor)
+			}
+			// break out of the loop
+			cur = ""
+		} else {
+			project, err := m.resourceManagerV3.Projects.Get(cur).Do()
+			if err != nil {
+				return nil, handleCRMError(cur, err)
+			}
+			ancestors = append(ancestors, project.Name)
+			cur = project.Parent
+		}
 	}
-	str := strings.Join(path, "/")
-	return sanitizeAncestryPath(str)
+	m.store(key, ancestors)
+	return ancestors, nil
 }
 
-func sanitizeAncestryPath(s string) string {
-	ret := s
-	// convert back to match existing ancestry path style.
+func handleCRMError(resource string, err error) error {
+	if isGoogleApiErrorWithCode(err, 403) {
+		helperURL := "https://cloud.google.com/docs/terraform/policy-validation/troubleshooting#ProjectCallerForbidden"
+		return fmt.Errorf("user does not have the correct permissions for %s. For more info: %s", resource, helperURL)
+	}
+	return err
+}
+
+func (m *manager) store(key string, ancestors []string) {
+	if key == "" || len(ancestors) == 0 {
+		return
+	}
+	if _, ok := m.ancestorCache[key]; !ok {
+		m.ancestorCache[key] = ancestors
+	}
+	// cache ancestors along the ancestry path
+	for i, ancestor := range ancestors {
+		if _, ok := m.ancestorCache[ancestor]; !ok {
+			m.ancestorCache[ancestor] = ancestors[i:]
+		}
+	}
+}
+
+func parseAncestryPath(path string) ([]string, error) {
+	normStr := normalizeAncestry(path)
+	splits := strings.Split(normStr, "/")
+	if len(splits)%2 != 0 {
+		return nil, fmt.Errorf("unexpected format of ancestry path %s", path)
+	}
+	var ancestors []string
+	allowedPrefixes := map[string]bool{
+		"projects":      true,
+		"folders":       true,
+		"organizations": true,
+	}
+	for i := 0; i < len(splits); i = i + 2 {
+		if _, ok := allowedPrefixes[splits[i]]; !ok {
+			return nil, fmt.Errorf("invalid ancestry path %s with %s", path, splits[i])
+		}
+		ancestors = append(ancestors, fmt.Sprintf("%s/%s", splits[i], splits[i+1]))
+	}
+	// reverse the sequence
+	i, j := 0, len(ancestors)-1
+	for i < j {
+		ancestors[i], ancestors[j] = ancestors[j], ancestors[i]
+		i++
+		j--
+	}
+	return ancestors, nil
+}
+
+func normalizeAncestry(val string) string {
 	for _, r := range []struct {
 		old string
 		new string
 	}{
-		{"organizations/", "organization/"},
-		{"folders/", "folder/"},
-		{"projects/", "project/"},
+		{"organization/", "organizations/"},
+		{"folder/", "folders/"},
+		{"project/", "projects/"},
 	} {
-		ret = strings.ReplaceAll(ret, r.old, r.new)
+		val = strings.ReplaceAll(val, r.old, r.new)
 	}
-	return ret
+	return val
 }
 
-func getProjectFromSchema(projectSchemaField string, d resources.TerraformResourceData, config *resources.Config) (string, error) {
-	res, ok := d.GetOk(projectSchemaField)
-	if ok && projectSchemaField != "" {
-		return res.(string), nil
+// getProjectFromResource reads the "project" field from the given resource data and falls
+// back to the provider's value if not given. If the provider's value is not
+// given, an error is returned.
+func (m *manager) getProjectFromResource(d resources.TerraformResourceData, config *resources.Config, cai *resources.Asset) (string, error) {
+
+	switch cai.Type {
+	case "cloudresourcemanager.googleapis.com/Project",
+		"cloudbilling.googleapis.com/ProjectBillingInfo":
+		res, ok := d.GetOk("number")
+		if ok {
+			return res.(string), nil
+		}
+
+		res, ok = d.GetOk("parent")
+		if ok && strings.HasPrefix(res.(string), "projects/") {
+			return res.(string), nil
+		}
+
+		// Fall back to project_id if number is not available.
+		res, ok = d.GetOk("project_id")
+		if ok {
+			return res.(string), nil
+		} else {
+			m.errorLogger.Warn(fmt.Sprintf("Failed to retrieve project_id for %s from resource", cai.Name))
+		}
+	case "storage.googleapis.com/Bucket":
+		if cai.Resource != nil {
+			res, ok := cai.Resource.Data["project"]
+			if ok {
+				return res.(string), nil
+			}
+		}
+		m.errorLogger.Warn(fmt.Sprintf("Failed to retrieve project_id for %s from cai resource", cai.Name))
+
+		bucketField, ok := d.GetOk("bucket")
+		if ok {
+			bucket := bucketField.(string)
+			resp, err := m.storageClient.Buckets.Get(bucket).Do()
+			if err == nil {
+				projectNum := resp.ProjectNumber
+				return strconv.Itoa(int(projectNum)), nil
+			}
+			m.errorLogger.Warn(fmt.Sprintf("Failed to get bucket %s", bucket))
+		}
+		m.errorLogger.Warn("Failed to retrieve bucket field from tf data")
 	}
-	res, ok = d.GetOk("parent")
-	if ok && strings.HasPrefix(res.(string), "projects/") {
-		return res.(string), nil
-	}
-	if config.Project != "" {
-		return config.Project, nil
-	}
-	return "", fmt.Errorf("required field '%s' is not set, you may use --project=my-project to provide a default project to resolve the issue", projectSchemaField)
+
+	return getProjectFromSchema("project", d, config)
 }
 
-// getOrganizationFromResource reads org_id field from terraform data.
-func getOrganizationFromResource(tfData resources.TerraformResourceData) (string, bool) {
-	orgID, ok := tfData.GetOk("org_id")
-	if ok {
-		return orgID.(string), ok
-	}
-	orgID, ok = tfData.GetOk("parent")
-	if ok && strings.HasPrefix(orgID.(string), "organizations/") {
-		return orgID.(string), ok
-	}
-	return "", false
-}
+type NoOpAncestryManager struct{}
 
-// getFolderFromResource reads folder_id, folder, parent or display_name field from terraform data.
-func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool) {
-	folderID, ok := tfData.GetOk("folder_id")
-	if ok {
-		return folderID.(string), ok
-	}
-	folderID, ok = tfData.GetOk("folder")
-	if ok {
-		return folderID.(string), ok
-	}
-	// folder name is store in display_name for google_folder
-	folderID, ok = tfData.GetOk("display_name")
-	if ok {
-		return folderID.(string), ok
-	}
-
-	// google_folder and google_org_policy_policy have {parent} field for ancestors
-	folderID, ok = tfData.GetOk("parent")
-	if ok && strings.HasPrefix(folderID.(string), "folders/") {
-		return folderID.(string), ok
-	}
-	return "", false
-}
-
-// isGoogleApiErrorWithCode cheks if the error code is of given type or not.
-func isGoogleApiErrorWithCode(err error, errCode int) bool {
-	gerr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error)
-	return ok && gerr != nil && gerr.Code == errCode
+func (*NoOpAncestryManager) Ancestors(config *resources.Config, tfData resources.TerraformResourceData, cai *resources.Asset) ([]string, string, error) {
+	return nil, "", nil
 }

--- a/ancestrymanager/ancestrymanager.go
+++ b/ancestrymanager/ancestrymanager.go
@@ -327,7 +327,6 @@ func (m *manager) getProjectFromResource(d resources.TerraformResourceData, conf
 		if ok {
 			return res.(string), nil
 		}
-		
 		// Fall back to project_id if number is not available.
 		res, ok = d.GetOk("project_id")
 		if ok {

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -470,6 +470,22 @@ func TestGetAncestors(t *testing.T) {
 			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
 		},
 		{
+			name: "Google folder with both folder_id and parent fields present",
+			data: tfdata.NewFakeResourceData(
+				"google_folder",
+				p.ResourcesMap["google_folder"].Schema,
+				map[string]interface{}{
+					"folder_id": "bar",
+					"parent":    "organizations/qux",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"folders/bar", "organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
+		{
 			name: "Google folder with missing parent field",
 			data: tfdata.NewFakeResourceData(
 				"google_folder",

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -395,6 +395,80 @@ func TestGetAncestors(t *testing.T) {
 			wantOnlineError:  true,
 			wantOfflineError: true,
 		},
+		{
+			name: "Org policy v2 on Project",
+			data: tfdata.NewFakeResourceData(
+				"google_org_policy_policy",
+				p.ResourcesMap["google_org_policy_policy"].Schema,
+				map[string]interface{}{
+					"parent": "projects/foo",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Project",
+			},
+			want:       []string{"projects/foo", "folders/bar", "organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/folders/bar",
+		},
+		{
+			name: "Org policy v2 on Folder",
+			data: tfdata.NewFakeResourceData(
+				"google_org_policy_policy",
+				p.ResourcesMap["google_org_policy_policy"].Schema,
+				map[string]interface{}{
+					"parent": "folders/bar",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"folders/bar", "organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
+		{
+			name: "Org policy v2 on Organization",
+			data: tfdata.NewFakeResourceData(
+				"google_org_policy_policy",
+				p.ResourcesMap["google_org_policy_policy"].Schema,
+				map[string]interface{}{
+					"parent": "organizations/qux",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Organization",
+			},
+			want: []string{"organizations/qux"},
+		},
+		{
+			name: "Google folder with organizations/ as {parent}",
+			data: tfdata.NewFakeResourceData(
+				"google_folder",
+				p.ResourcesMap["google_folder"].Schema,
+				map[string]interface{}{
+					"parent": "organizations/qux",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
+		{
+			name: "Google folder with folders/ as {parent}",
+			data: tfdata.NewFakeResourceData(
+				"google_folder",
+				p.ResourcesMap["google_folder"].Schema,
+				map[string]interface{}{
+					"parent": "folders/bar",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"folders/bar", "organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
 	}
 	for _, c := range cases {
 		for _, offline := range []bool{true, false} {

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -445,22 +445,8 @@ func TestGetAncestors(t *testing.T) {
 				"google_folder",
 				p.ResourcesMap["google_folder"].Schema,
 				map[string]interface{}{
-					"parent": "organizations/qux",
-				},
-			),
-			asset: &resources.Asset{
-				Type: "cloudresourcemanager.googleapis.com/Folder",
-			},
-			want:       []string{"organizations/qux"},
-			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
-		},
-		{
-			name: "Google folder with folders/ as {parent}",
-			data: tfdata.NewFakeResourceData(
-				"google_folder",
-				p.ResourcesMap["google_folder"].Schema,
-				map[string]interface{}{
-					"parent": "folders/bar",
+					"display_name": "bar",
+					"parent":       "organizations/qux",
 				},
 			),
 			asset: &resources.Asset{

--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -445,8 +445,22 @@ func TestGetAncestors(t *testing.T) {
 				"google_folder",
 				p.ResourcesMap["google_folder"].Schema,
 				map[string]interface{}{
-					"display_name": "bar",
-					"parent":       "organizations/qux",
+					"parent": "organizations/qux",
+				},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"organizations/qux"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
+		{
+			name: "Google folder with folders/ as {parent}",
+			data: tfdata.NewFakeResourceData(
+				"google_folder",
+				p.ResourcesMap["google_folder"].Schema,
+				map[string]interface{}{
+					"parent": "folders/bar",
 				},
 			),
 			asset: &resources.Asset{
@@ -454,6 +468,19 @@ func TestGetAncestors(t *testing.T) {
 			},
 			want:       []string{"folders/bar", "organizations/qux"},
 			wantParent: "//cloudresourcemanager.googleapis.com/organizations/qux",
+		},
+		{
+			name: "Google folder with missing parent field",
+			data: tfdata.NewFakeResourceData(
+				"google_folder",
+				p.ResourcesMap["google_folder"].Schema,
+				map[string]interface{}{},
+			),
+			asset: &resources.Asset{
+				Type: "cloudresourcemanager.googleapis.com/Folder",
+			},
+			want:       []string{"organizations/unknown"},
+			wantParent: "//cloudresourcemanager.googleapis.com/organizations/unknown",
 		},
 	}
 	for _, c := range cases {

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -108,7 +108,6 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 	if ok {
 		return folderID.(string), ok
 	}
-
 	folderID, ok = tfData.GetOk("folder")
 	if ok {
 		return folderID.(string), ok

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -79,6 +79,10 @@ func getProjectFromSchema(projectSchemaField string, d resources.TerraformResour
 	if ok && projectSchemaField != "" {
 		return res.(string), nil
 	}
+	res, ok = d.GetOk("parent")
+	if ok && strings.HasPrefix(res.(string), "projects/"){
+		return res.(string), nil
+	}
 	if config.Project != "" {
 		return config.Project, nil
 	}
@@ -89,6 +93,10 @@ func getProjectFromSchema(projectSchemaField string, d resources.TerraformResour
 func getOrganizationFromResource(tfData resources.TerraformResourceData) (string, bool) {
 	orgID, ok := tfData.GetOk("org_id")
 	if ok {
+		return orgID.(string), ok
+	}
+	orgID, ok = tfData.GetOk("parent")
+	if ok && strings.HasPrefix(orgID.(string), "organizations/"){
 		return orgID.(string), ok
 	}
 	return "", false
@@ -102,6 +110,10 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 	}
 	folderID, ok = tfData.GetOk("folder")
 	if ok {
+		return folderID.(string), ok
+	}
+	folderID, ok = tfData.GetOk("parent")
+	if ok && strings.HasPrefix(folderID.(string), "folders/"){
 		return folderID.(string), ok
 	}
 	return "", false

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -102,7 +102,7 @@ func getOrganizationFromResource(tfData resources.TerraformResourceData) (string
 	return "", false
 }
 
-// getFolderFromResource reads folder_id, folder, parent or display_name field from terraform data.
+// getFolderFromResource reads folder_id, folder, parent field from terraform data.
 func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool) {
 	folderID, ok := tfData.GetOk("folder_id")
 	if ok {
@@ -112,13 +112,7 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 	if ok {
 		return folderID.(string), ok
 	}
-	// folder name is store in display_name for google_folder
-	folderID, ok = tfData.GetOk("display_name")
-	if ok {
-		return folderID.(string), ok
-	}
 
-	// google_folder and google_org_policy_policy have {parent} field for ancestors
 	folderID, ok = tfData.GetOk("parent")
 	if ok && strings.HasPrefix(folderID.(string), "folders/") {
 		return folderID.(string), ok

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -111,10 +111,7 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 
 	folderID, ok = tfData.GetOk("folder")
 	if ok {
-		if strings.HasPrefix(folderID.(string), "folders/") {
-			return folderID.(string), ok
-		}
-		return fmt.Sprintf("folders/%s", folderID.(string)), ok
+		return folderID.(string), ok
 	}
 
 	folderID, ok = tfData.GetOk("parent")

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -80,7 +80,7 @@ func getProjectFromSchema(projectSchemaField string, d resources.TerraformResour
 		return res.(string), nil
 	}
 	res, ok = d.GetOk("parent")
-	if ok && strings.HasPrefix(res.(string), "projects/"){
+	if ok && strings.HasPrefix(res.(string), "projects/") {
 		return res.(string), nil
 	}
 	if config.Project != "" {
@@ -96,13 +96,13 @@ func getOrganizationFromResource(tfData resources.TerraformResourceData) (string
 		return orgID.(string), ok
 	}
 	orgID, ok = tfData.GetOk("parent")
-	if ok && strings.HasPrefix(orgID.(string), "organizations/"){
+	if ok && strings.HasPrefix(orgID.(string), "organizations/") {
 		return orgID.(string), ok
 	}
 	return "", false
 }
 
-// getFolderFromResource reads folder_id or folder field from terraform data.
+// getFolderFromResource reads folder_id, folder, parent or display_name field from terraform data.
 func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool) {
 	folderID, ok := tfData.GetOk("folder_id")
 	if ok {
@@ -112,8 +112,15 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 	if ok {
 		return folderID.(string), ok
 	}
+	// folder name is store in display_name for google_folder
+	folderID, ok = tfData.GetOk("display_name")
+	if ok {
+		return folderID.(string), ok
+	}
+
+	// google_folder and google_org_policy_policy have {parent} field for ancestors
 	folderID, ok = tfData.GetOk("parent")
-	if ok && strings.HasPrefix(folderID.(string), "folders/"){
+	if ok && strings.HasPrefix(folderID.(string), "folders/") {
 		return folderID.(string), ok
 	}
 	return "", false

--- a/ancestrymanager/ancestryutil.go
+++ b/ancestrymanager/ancestryutil.go
@@ -108,9 +108,13 @@ func getFolderFromResource(tfData resources.TerraformResourceData) (string, bool
 	if ok {
 		return folderID.(string), ok
 	}
+
 	folderID, ok = tfData.GetOk("folder")
 	if ok {
-		return folderID.(string), ok
+		if strings.HasPrefix(folderID.(string), "folders/") {
+			return folderID.(string), ok
+		}
+		return fmt.Sprintf("folders/%s", folderID.(string)), ok
 	}
 
 	folderID, ok = tfData.GetOk("parent")


### PR DESCRIPTION
The PR handles ancestryManager module for the following changes:
1. google_org_policy_policy: The parent information resides in {parent} field of the plan file. The existing logic only looks up {folder_id}, {org_id} etc. for the same. The PR also does a lookup on the {parent} field, after matching for assetType.
2. google_folder: Parent maybe an organization or folder, so it does lookup for both.