### PR TITLE
Changed terraform provider being used from google to google-beta

### DIFF
--- a/ancestrymanager/ancestrymanager_test.go
+++ b/ancestrymanager/ancestrymanager_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-validator/tfdata"
 
 	"github.com/google/go-cmp/cmp"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"go.uber.org/zap"
 	crmv1 "google.golang.org/api/cloudresourcemanager/v1"
 	crmv3 "google.golang.org/api/cloudresourcemanager/v3"

--- a/cmd/list_unsupported_resources.go
+++ b/cmd/list_unsupported_resources.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 
 	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"github.com/spf13/cobra"
 )
 

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -29,7 +29,7 @@ import (
 
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )

--- a/converters/google/convert.go
+++ b/converters/google/convert.go
@@ -185,9 +185,9 @@ func (c *Converter) AddResourceChanges(changes []*tfjson.ResourceChange) error {
 			c.errorLogger.Debug(fmt.Sprintf("%s: resource uses the google-beta provider and may not be convertible", rc.Address))
 		}
 
-		// Skip resources not found in the google GA provider's schema
+		// Skip resources not found in the google GA or beta provider's schema
 		if _, ok := c.schema.ResourcesMap[rc.Type]; !ok {
-			c.errorLogger.Debug(fmt.Sprintf("%s: resource type not found in google GA provider: %s.", rc.Address, rc.Type))
+			c.errorLogger.Debug(fmt.Sprintf("%s: resource type not found in google GA or beta provider: %s.", rc.Address, rc.Type))
 			continue
 		}
 

--- a/converters/google/convert_test.go
+++ b/converters/google/convert_test.go
@@ -27,7 +27,7 @@ import (
 	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfdata"
 	tfjson "github.com/hashicorp/terraform-json"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"

--- a/docs/contributing/add_new_resource.md
+++ b/docs/contributing/add_new_resource.md
@@ -46,7 +46,7 @@ Adding support for a resource has four steps:
 
 Each of these is discussed in more detail below.
 
-**Note**: terraform-validator can only support resources that are supported by the GA terraform provider, not beta resources.
+**Note**: terraform-validator can support resources that are supported by both GA and beta terraform provider.
 
 ### 1. Magic Modules
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,8 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
-	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72
+	github.com/hashicorp/terraform-provider-google v1.20.1-0.20230328023035-2a66426b3714
+	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230327033815-6a987a080e13
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.8.0 // indirect
+	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
-	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67
+	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
-	github.com/hashicorp/terraform-provider-google v1.20.1-0.20230323165411-b56d5b17f674
+	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
@@ -115,7 +115,6 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-mux v0.8.0 // indirect
-	github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,8 @@ github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0 h1:FtCLTiTcykdsURXPt/ku7fYX
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0/go.mod h1:80wf5oad1tW+oLnbXS4UTYmDCrl7BuN1Q+IA91X1a4Y=
 github.com/hashicorp/terraform-provider-google v1.20.1-0.20230322214059-efcff70c7d0d h1:M9Y+0Fs4IWMQkhvjXi/CR1nWWkI+C9vFHe1uRKc2QKk=
 github.com/hashicorp/terraform-provider-google v1.20.1-0.20230322214059-efcff70c7d0d/go.mod h1:Wn+5oEyIb0xoRzKqjLIZ8DE7bvH9WQ68mAb3G8RJrcE=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67 h1:idWDNw7XhxTyAwXgVhVfIvh0OxT8B6QHyA6dIYVfmII=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67/go.mod h1:6T90oLRyHe2yswP2YxGtiGiC05xKdA50puG9WPnuQic=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=
 github.com/hashicorp/terraform-registry-address v0.1.0/go.mod h1:EnyO2jYO6j29DTHbJcm00E5nQTFeTtyZH3H5ycydQ5A=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/go.sum
+++ b/go.sum
@@ -545,6 +545,8 @@ github.com/hashicorp/terraform-json v0.14.0 h1:sh9iZ1Y8IFJLx+xQiKHGud6/TSUCM0N8e
 github.com/hashicorp/terraform-json v0.14.0/go.mod h1:5A9HIWPkk4e5aeeXIBbkcOvaZbIYnAIkEyqP2pNSckM=
 github.com/hashicorp/terraform-plugin-framework v1.1.1 h1:PbnEKHsIU8KTTzoztHQGgjZUWx7Kk8uGtpGMMc1p+oI=
 github.com/hashicorp/terraform-plugin-framework v1.1.1/go.mod h1:DyZPxQA+4OKK5ELxFIIcqggcszqdWWUpTLPHAhS/tkY=
+github.com/hashicorp/terraform-plugin-framework-validators v0.9.0 h1:LYz4bXh3t7bTEydXOmPDPupRRnA480B/9+jV8yZvxBA=
+github.com/hashicorp/terraform-plugin-framework-validators v0.9.0/go.mod h1:+BVERsnfdlhYR2YkXMBtPnmn9UsL19U3qUtSZ+Y/5MY=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
@@ -553,8 +555,10 @@ github.com/hashicorp/terraform-plugin-mux v0.8.0 h1:WCTP66mZ+iIaIrCNJnjPEYnVjawT
 github.com/hashicorp/terraform-plugin-mux v0.8.0/go.mod h1:vdW0daEi8Kd4RFJmet5Ot+SIVB/B8SwQVJiYKQwdCy8=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0 h1:FtCLTiTcykdsURXPt/ku7fYXm3y19nbzbZcUxHx9RbI=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0/go.mod h1:80wf5oad1tW+oLnbXS4UTYmDCrl7BuN1Q+IA91X1a4Y=
-github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72 h1:ZiJs9Uy5ORMmRuQu2j65cSPrUZJ4dzPhlNBVnjATMEI=
-github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72/go.mod h1:6T90oLRyHe2yswP2YxGtiGiC05xKdA50puG9WPnuQic=
+github.com/hashicorp/terraform-provider-google v1.20.1-0.20230328023035-2a66426b3714 h1:1khay+n2a9OpqR+FHERqMWgi1mK+Bc3tKj8XiSnjRx8=
+github.com/hashicorp/terraform-provider-google v1.20.1-0.20230328023035-2a66426b3714/go.mod h1:Wn+5oEyIb0xoRzKqjLIZ8DE7bvH9WQ68mAb3G8RJrcE=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230327033815-6a987a080e13 h1:OY1cV8noploAYVjdqUgu2RU8Y20F+X7p4fSduqzYPe8=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230327033815-6a987a080e13/go.mod h1:6T90oLRyHe2yswP2YxGtiGiC05xKdA50puG9WPnuQic=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=
 github.com/hashicorp/terraform-registry-address v0.1.0/go.mod h1:EnyO2jYO6j29DTHbJcm00E5nQTFeTtyZH3H5ycydQ5A=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,8 @@ github.com/hashicorp/terraform-plugin-mux v0.8.0 h1:WCTP66mZ+iIaIrCNJnjPEYnVjawT
 github.com/hashicorp/terraform-plugin-mux v0.8.0/go.mod h1:vdW0daEi8Kd4RFJmet5Ot+SIVB/B8SwQVJiYKQwdCy8=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0 h1:FtCLTiTcykdsURXPt/ku7fYXm3y19nbzbZcUxHx9RbI=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0/go.mod h1:80wf5oad1tW+oLnbXS4UTYmDCrl7BuN1Q+IA91X1a4Y=
-github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67 h1:idWDNw7XhxTyAwXgVhVfIvh0OxT8B6QHyA6dIYVfmII=
-github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230322214054-60416c59ce67/go.mod h1:6T90oLRyHe2yswP2YxGtiGiC05xKdA50puG9WPnuQic=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72 h1:ZiJs9Uy5ORMmRuQu2j65cSPrUZJ4dzPhlNBVnjATMEI=
+github.com/hashicorp/terraform-provider-google-beta v1.20.1-0.20230324233649-b8e2c1c9ac72/go.mod h1:6T90oLRyHe2yswP2YxGtiGiC05xKdA50puG9WPnuQic=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=
 github.com/hashicorp/terraform-registry-address v0.1.0/go.mod h1:EnyO2jYO6j29DTHbJcm00E5nQTFeTtyZH3H5ycydQ5A=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKLsbzeOsfXmKNpr3GiT18XAblV0BjCbzL8KQAMZGa0=

--- a/test/iam_test.go
+++ b/test/iam_test.go
@@ -16,7 +16,7 @@ import (
 	resources "github.com/GoogleCloudPlatform/terraform-validator/converters/google/resources"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfdata"
 	"github.com/GoogleCloudPlatform/terraform-validator/tfplan"
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 )
 
 func TestIAMFetchFullResource(t *testing.T) {

--- a/tfdata/fake_resource_data_test.go
+++ b/tfdata/fake_resource_data_test.go
@@ -16,7 +16,7 @@ package tfdata
 import (
 	"testing"
 
-	provider "github.com/hashicorp/terraform-provider-google/google"
+	provider "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
Use Case: To add support for org-policy custom-constraints in terraform-validator (which is a non GA resource, hence supported in terraform/google-beta provider) the provider currently being used in terraform-validator is modified from google to google-beta in this PR.