### PR TITLE
Fix asset count

### DIFF
--- a/tfgcv/planned_assets_test.go
+++ b/tfgcv/planned_assets_test.go
@@ -55,7 +55,7 @@ func testCases(t *testing.T) []testcase {
 		{
 			"Test TF0_12 with no-op",
 			args{"tf0_12plan.applied.json", "foobar", testAncestryName, true},
-			6,
+			7,
 			false,
 			map[string]string{
 				"projects/345":    testAncestryName,
@@ -86,7 +86,7 @@ func testCases(t *testing.T) []testcase {
 		{
 			"Test TF1_0 with no-op",
 			args{"tf1_0plan.applied.json", "foobar", testAncestryName, true},
-			6,
+			7,
 			false,
 			map[string]string{
 				"projects/345":    testAncestryName,


### PR DESCRIPTION
Folder convert logic in magic module PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/7246, is adding one more converted asset. Thus fixing the count of converted asset.