### PR TITLE
Updated go version to 1.19

### DIFF
--- a/.ci/cloudbuild-tests-go-licenses.yaml
+++ b/.ci/cloudbuild-tests-go-licenses.yaml
@@ -17,7 +17,7 @@
 timeout: 1800s
 steps:
 - id: build
-  name: 'gcr.io/cloud-builders/go:1.18'
+  name: 'gcr.io/cloud-builders/go:1.19'
   entrypoint: /usr/bin/make
   args: ['build']
 - id: test-go-licenses

--- a/.ci/cloudbuild-tests-unit.yaml
+++ b/.ci/cloudbuild-tests-unit.yaml
@@ -17,11 +17,11 @@
 timeout: 1800s
 steps:
 - id: build
-  name: 'gcr.io/cloud-builders/go:1.18'
+  name: 'gcr.io/cloud-builders/go:1.19'
   entrypoint: /usr/bin/make
   args: ['build']
 - id: test
-  name: 'gcr.io/cloud-builders/go:1.18'
+  name: 'gcr.io/cloud-builders/go:1.19'
   entrypoint: /usr/bin/make
   args: ['test']
   env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 RUN apt-get update && apt-get -y install wget unzip
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
-go 1.18
+go 1.19
 
 // Prevent otel dependencies from getting out of sync.
 // Cannot be upgraded until k8s.io/component-base uses a more recent version of


### PR DESCRIPTION
Fixes failing image build https://pantheon.corp.google.com/cloud-build/builds/cdfbc10b-2459-49e4-961f-44ca89b8f82b;step=0?jsmode=O&mods=logs_tg_staging&project=config-validator Follow-up for https://github.com/GoogleCloudPlatform/magic-modules/pull/7557