### PR TITLE
Revert "Updated go version to 1.19"

### DIFF
--- a/.ci/cloudbuild-tests-go-licenses.yaml
+++ b/.ci/cloudbuild-tests-go-licenses.yaml
@@ -17,7 +17,7 @@
 timeout: 1800s
 steps:
 - id: build
-  name: 'gcr.io/cloud-builders/go:1.19'
+  name: 'gcr.io/cloud-builders/go:1.18'
   entrypoint: /usr/bin/make
   args: ['build']
 - id: test-go-licenses

--- a/.ci/cloudbuild-tests-unit.yaml
+++ b/.ci/cloudbuild-tests-unit.yaml
@@ -17,11 +17,11 @@
 timeout: 1800s
 steps:
 - id: build
-  name: 'gcr.io/cloud-builders/go:1.19'
+  name: 'gcr.io/cloud-builders/go:1.18'
   entrypoint: /usr/bin/make
   args: ['build']
 - id: test
-  name: 'gcr.io/cloud-builders/go:1.19'
+  name: 'gcr.io/cloud-builders/go:1.18'
   entrypoint: /usr/bin/make
   args: ['test']
   env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.18
 
 RUN apt-get update && apt-get -y install wget unzip
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/terraform-validator
 
-go 1.19
+go 1.18
 
 // Prevent otel dependencies from getting out of sync.
 // Cannot be upgraded until k8s.io/component-base uses a more recent version of


### PR DESCRIPTION
Reverts GoogleCloudPlatform/terraform-validator#1509 - downstream build pipeline is not compatible with go 1.19.